### PR TITLE
fix: multicast keep-aliveの実装を改善してIGMP準拠にする

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -88,7 +88,6 @@ type Config struct {
 	// Multicast keep-alive settings
 	Multicast struct {
 		KeepAliveEnabled      bool   `toml:"keep_alive_enabled"`
-		HeartbeatInterval     string `toml:"heartbeat_interval"`     // e.g., "30s", "1m"
 		GroupRefreshInterval  string `toml:"group_refresh_interval"` // e.g., "5m", "10m"
 		NetworkMonitorEnabled bool   `toml:"network_monitor_enabled"`
 	} `toml:"multicast"`
@@ -113,7 +112,6 @@ func NewConfig() *Config {
 
 	// Default multicast keep-alive settings
 	cfg.Multicast.KeepAliveEnabled = true
-	cfg.Multicast.HeartbeatInterval = "30s"
 	cfg.Multicast.GroupRefreshInterval = "5m"
 	cfg.Multicast.NetworkMonitorEnabled = true
 

--- a/echonet_lite/network/UDPConnection_keepalive_test.go
+++ b/echonet_lite/network/UDPConnection_keepalive_test.go
@@ -11,7 +11,6 @@ func TestKeepAliveConfig(t *testing.T) {
 	// テスト用のキープアライブ設定
 	config := &KeepAliveConfig{
 		Enabled:               true,
-		HeartbeatInterval:     1 * time.Second,
 		GroupRefreshInterval:  2 * time.Second,
 		NetworkMonitorEnabled: true,
 	}
@@ -31,16 +30,12 @@ func TestKeepAliveConfig(t *testing.T) {
 	defer conn.Close()
 
 	// キープアライブ状態をチェック
-	enabled, lastHeartbeat, lastGroupRefresh := conn.GetKeepAliveStatus()
+	enabled, lastGroupRefresh := conn.GetKeepAliveStatus()
 	if !enabled {
 		t.Error("キープアライブが有効になっていません")
 	}
 
-	// 少し待機してからハートビートとグループ更新をテスト
-	time.Sleep(100 * time.Millisecond)
-
-	// 手動でハートビートをトリガー
-	conn.TriggerHeartbeat()
+	// 少し待機してからグループ更新をテスト
 	time.Sleep(100 * time.Millisecond)
 
 	// 手動でグループ更新をトリガー
@@ -48,10 +43,7 @@ func TestKeepAliveConfig(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 
 	// 状態が更新されているかチェック
-	_, newLastHeartbeat, newLastGroupRefresh := conn.GetKeepAliveStatus()
-	if !newLastHeartbeat.After(lastHeartbeat) {
-		t.Error("ハートビートが更新されていません")
-	}
+	_, newLastGroupRefresh := conn.GetKeepAliveStatus()
 	if !newLastGroupRefresh.After(lastGroupRefresh) {
 		t.Error("グループ更新が実行されていません")
 	}
@@ -78,7 +70,7 @@ func TestKeepAliveDisabled(t *testing.T) {
 	defer conn.Close()
 
 	// キープアライブ状態をチェック
-	enabled, _, _ := conn.GetKeepAliveStatus()
+	enabled, _ := conn.GetKeepAliveStatus()
 	if enabled {
 		t.Error("キープアライブが無効になっていません")
 	}
@@ -100,7 +92,7 @@ func TestKeepAliveNilConfig(t *testing.T) {
 	defer conn.Close()
 
 	// キープアライブ状態をチェック
-	enabled, _, _ := conn.GetKeepAliveStatus()
+	enabled, _ := conn.GetKeepAliveStatus()
 	if enabled {
 		t.Error("キープアライブが無効になっていません")
 	}
@@ -121,7 +113,7 @@ func TestCreateUDPConnectionBackwardCompatibility(t *testing.T) {
 	defer conn.Close()
 
 	// キープアライブが無効であることを確認
-	enabled, _, _ := conn.GetKeepAliveStatus()
+	enabled, _ := conn.GetKeepAliveStatus()
 	if enabled {
 		t.Error("デフォルトでキープアライブが有効になっています")
 	}

--- a/main.go
+++ b/main.go
@@ -119,8 +119,8 @@ func main() {
 
 		// キープアライブ設定の表示
 		if cfg.Multicast.KeepAliveEnabled {
-			fmt.Printf("マルチキャストキープアライブ: 有効 (ハートビート: %s, グループ更新: %s, ネットワーク監視: %v)\n",
-				cfg.Multicast.HeartbeatInterval, cfg.Multicast.GroupRefreshInterval, cfg.Multicast.NetworkMonitorEnabled)
+			fmt.Printf("マルチキャストキープアライブ: 有効 (グループ更新: %s, ネットワーク監視: %v)\n",
+				cfg.Multicast.GroupRefreshInterval, cfg.Multicast.NetworkMonitorEnabled)
 		} else {
 			fmt.Println("マルチキャストキープアライブ: 無効")
 		}
@@ -258,8 +258,8 @@ func main() {
 
 		// キープアライブ設定の表示
 		if cfg.Multicast.KeepAliveEnabled {
-			fmt.Printf("マルチキャストキープアライブ: 有効 (ハートビート: %s, グループ更新: %s, ネットワーク監視: %v)\n",
-				cfg.Multicast.HeartbeatInterval, cfg.Multicast.GroupRefreshInterval, cfg.Multicast.NetworkMonitorEnabled)
+			fmt.Printf("マルチキャストキープアライブ: 有効 (グループ更新: %s, ネットワーク監視: %v)\n",
+				cfg.Multicast.GroupRefreshInterval, cfg.Multicast.NetworkMonitorEnabled)
 		} else {
 			fmt.Println("マルチキャストキープアライブ: 無効")
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -20,11 +20,6 @@ func NewServer(ctx context.Context, cfg *config.Config) (*Server, error) {
 
 	// キープアライブ設定を追加
 	if cfg != nil && cfg.Multicast.KeepAliveEnabled {
-		heartbeatInterval, err := time.ParseDuration(cfg.Multicast.HeartbeatInterval)
-		if err != nil {
-			heartbeatInterval = 30 * time.Second // デフォルト値
-		}
-
 		groupRefreshInterval, err := time.ParseDuration(cfg.Multicast.GroupRefreshInterval)
 		if err != nil {
 			groupRefreshInterval = 5 * time.Minute // デフォルト値
@@ -32,7 +27,6 @@ func NewServer(ctx context.Context, cfg *config.Config) (*Server, error) {
 
 		options.KeepAliveConfig = &network.KeepAliveConfig{
 			Enabled:               cfg.Multicast.KeepAliveEnabled,
-			HeartbeatInterval:     heartbeatInterval,
 			GroupRefreshInterval:  groupRefreshInterval,
 			NetworkMonitorEnabled: cfg.Multicast.NetworkMonitorEnabled,
 		}


### PR DESCRIPTION
## 概要

commit c784b96 でマージされたmulticast keep-alive実装の問題を修正し、IGMP準拠の実装に改善しました。

## 主な変更点

### 🚫 削除された機能
- **ハートビートパケット送信機能**: IGMP仕様に違反していた1バイトの `0x00` パケット送信を削除
- **HeartbeatInterval設定**: 関連する設定項目と処理を完全に削除

### 🔧 修正された問題
- **競合状態**: `stopKeepAlive()` での不適切な同期を修正
- **goroutine終了**: `done` チャンネルによる適切な終了待機を実装
- **ポインタアクセス**: 並行アクセス時の nil 参照問題を解決
- **エラーハンドリング**: ネットワーク関連エラーの回復処理を強化

### ✅ IGMP準拠の改善
- `net.ListenMulticastUDP` による自動グループ参加に依存
- IGMPクエリ/レポート機構をOSカーネルに委任
- ネットワーク変更時のグループメンバーシップ確認のみ実行

## 技術詳細

### 調査結果
IPv4 multicast keep-aliveについて調査した結果：
1. **IGMP仕様**: 通常はルーターからのクエリに対してレポートで応答
2. **タイムアウト値**: デフォルト60-125秒のクエリ間隔、260秒のタイムアウト
3. **実装方式**: アプリケーションレベルのハートビートは不要

### 修正内容
- `MulticastKeepAlive` 構造体からハートビート関連フィールドを削除
- `keepAliveLoop()` でハートビート処理を削除
- `done` チャンネルによる適切なgoroutine同期を追加
- エラー時の継続処理を改善

## テスト結果

```bash
$ go test ./echonet_lite/network/ -v
=== RUN   TestKeepAliveConfig
--- PASS: TestKeepAliveConfig (0.20s)
=== RUN   TestKeepAliveDisabled  
--- PASS: TestKeepAliveDisabled (0.00s)
=== RUN   TestKeepAliveNilConfig
--- PASS: TestKeepAliveNilConfig (0.00s)
=== RUN   TestCreateUDPConnectionBackwardCompatibility
--- PASS: TestCreateUDPConnectionBackwardCompatibility (0.00s)
PASS
```

## Breaking Changes

⚠️ **設定ファイルの変更が必要**

```toml
[multicast]
# 削除: heartbeat_interval = "30s"  
keep_alive_enabled = true
group_refresh_interval = "5m"
network_monitor_enabled = true
```

🤖 Generated with [Claude Code](https://claude.ai/code)