### PR TITLE
feat: WebSocket切断時のメッセージ表示を改善

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -160,11 +160,14 @@ function App() {
         </div>
         
 
-        {Object.keys(echonet.devices).length === 0 && echonet.connectionState === 'connected' ? (
+        {Object.keys(echonet.devices).length === 0 ? (
           <Card>
             <CardContent className="pt-6">
               <p className="text-center text-muted-foreground">
-                No devices found. Click refresh to discover devices.
+                {echonet.connectionState === 'connected' 
+                  ? 'No devices found. Click refresh to discover devices.'
+                  : `サーバーに接続できません (${echonet.connectionState})`
+                }
               </p>
             </CardContent>
           </Card>


### PR DESCRIPTION
WebSocketの接続状態に応じたメッセージ表示の改善

## 変更内容
デバイスが0件の時の表示メッセージをWebSocketの接続状態に応じて変更：
- 接続済み： "No devices found. Click refresh to discover devices."
- 未接続： "サーバーに接続できません (接続状態)"

Fixes #47

Generated with [Claude Code](https://claude.ai/code)