### PR TITLE
feat: web ui デバイスエイリアス編集機能を追加

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -62,6 +62,8 @@ function App() {
   
   // Loading state for update operations
   const [updatingDevices, setUpdatingDevices] = useState<Set<string>>(new Set());
+  // Track alias operations loading state
+  const [aliasLoading, setAliasLoading] = useState(false);
 
   // Property change handler
   const handlePropertyChange = async (target: string, epc: string, value: PropertyValue) => {
@@ -91,6 +93,32 @@ function App() {
         newSet.delete(target);
         return newSet;
       });
+    }
+  };
+
+  // Add alias handler
+  const handleAddAlias = async (alias: string, target: string) => {
+    try {
+      setAliasLoading(true);
+      await echonet.addAlias(alias, target);
+    } catch (error) {
+      console.error('Failed to add alias:', error);
+      throw error; // Re-throw to let AliasEditor handle the error
+    } finally {
+      setAliasLoading(false);
+    }
+  };
+
+  // Delete alias handler
+  const handleDeleteAlias = async (alias: string) => {
+    try {
+      setAliasLoading(true);
+      await echonet.deleteAlias(alias);
+    } catch (error) {
+      console.error('Failed to delete alias:', error);
+      throw error; // Re-throw to let AliasEditor handle the error
+    } finally {
+      setAliasLoading(false);
     }
   };
 
@@ -241,6 +269,9 @@ function App() {
                         getDeviceClassCode={echonet.getDeviceClassCode}
                         devices={echonet.devices}
                         aliases={echonet.aliases}
+                        onAddAlias={handleAddAlias}
+                        onDeleteAlias={handleDeleteAlias}
+                        isAliasLoading={aliasLoading}
                       />
                     );
                   })}

--- a/web/src/components/AliasEditor.test.tsx
+++ b/web/src/components/AliasEditor.test.tsx
@@ -1,0 +1,262 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { AliasEditor } from './AliasEditor';
+import type { Device } from '@/hooks/types';
+
+const mockDevice: Device = {
+  ip: '192.168.1.10',
+  eoj: '0130:1',
+  name: 'HomeAirConditioner',
+  id: '013001:00000B:ABCDEF0123456789ABCDEF012345',
+  properties: {},
+  lastSeen: '2023-04-01T12:00:00Z'
+};
+
+describe('AliasEditor', () => {
+  const mockOnAddAlias = vi.fn();
+  const mockOnDeleteAlias = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('when device has no alias', () => {
+    it('should show add button', () => {
+      render(
+        <AliasEditor
+          device={mockDevice}
+          currentAlias={undefined}
+          onAddAlias={mockOnAddAlias}
+          onDeleteAlias={mockOnDeleteAlias}
+        />
+      );
+
+      expect(screen.getByTitle('エイリアスを追加')).toBeInTheDocument();
+      expect(screen.queryByTitle('エイリアスを編集')).not.toBeInTheDocument();
+      expect(screen.queryByTitle('エイリアスを削除')).not.toBeInTheDocument();
+    });
+
+    it('should enter edit mode when add button is clicked', () => {
+      render(
+        <AliasEditor
+          device={mockDevice}
+          currentAlias={undefined}
+          onAddAlias={mockOnAddAlias}
+          onDeleteAlias={mockOnDeleteAlias}
+        />
+      );
+
+      const addButton = screen.getByTitle('エイリアスを追加');
+      fireEvent.click(addButton);
+
+      expect(screen.getByPlaceholderText('エイリアス名を入力')).toBeInTheDocument();
+      expect(screen.getByTitle('保存')).toBeInTheDocument();
+      expect(screen.getByTitle('キャンセル')).toBeInTheDocument();
+    });
+  });
+
+  describe('when device has alias', () => {
+    it('should show edit and delete buttons', () => {
+      render(
+        <AliasEditor
+          device={mockDevice}
+          currentAlias="living_ac"
+          onAddAlias={mockOnAddAlias}
+          onDeleteAlias={mockOnDeleteAlias}
+        />
+      );
+
+      expect(screen.getByText('living_ac')).toBeInTheDocument();
+      expect(screen.getByTitle('エイリアスを編集')).toBeInTheDocument();
+      expect(screen.getByTitle('エイリアスを削除')).toBeInTheDocument();
+    });
+
+    it('should enter edit mode with current alias when edit button is clicked', () => {
+      render(
+        <AliasEditor
+          device={mockDevice}
+          currentAlias="living_ac"
+          onAddAlias={mockOnAddAlias}
+          onDeleteAlias={mockOnDeleteAlias}
+        />
+      );
+
+      const editButton = screen.getByTitle('エイリアスを編集');
+      fireEvent.click(editButton);
+
+      const input = screen.getByDisplayValue('living_ac');
+      expect(input).toBeInTheDocument();
+    });
+
+    it('should call onDeleteAlias when delete button is clicked', async () => {
+      render(
+        <AliasEditor
+          device={mockDevice}
+          currentAlias="living_ac"
+          onAddAlias={mockOnAddAlias}
+          onDeleteAlias={mockOnDeleteAlias}
+        />
+      );
+
+      const deleteButton = screen.getByTitle('エイリアスを削除');
+      fireEvent.click(deleteButton);
+
+      await waitFor(() => {
+        expect(mockOnDeleteAlias).toHaveBeenCalledWith('living_ac');
+      });
+    });
+  });
+
+  describe('edit mode validation', () => {
+    it('should show error for empty alias', async () => {
+      render(
+        <AliasEditor
+          device={mockDevice}
+          currentAlias={undefined}
+          onAddAlias={mockOnAddAlias}
+          onDeleteAlias={mockOnDeleteAlias}
+        />
+      );
+
+      const addButton = screen.getByTitle('エイリアスを追加');
+      fireEvent.click(addButton);
+
+      const saveButton = screen.getByTitle('保存');
+      fireEvent.click(saveButton);
+
+      expect(screen.getByText('エイリアス名を入力してください')).toBeInTheDocument();
+    });
+
+    it('should show error for hex-like alias', async () => {
+      render(
+        <AliasEditor
+          device={mockDevice}
+          currentAlias={undefined}
+          onAddAlias={mockOnAddAlias}
+          onDeleteAlias={mockOnDeleteAlias}
+        />
+      );
+
+      const addButton = screen.getByTitle('エイリアスを追加');
+      fireEvent.click(addButton);
+
+      const input = screen.getByPlaceholderText('エイリアス名を入力');
+      fireEvent.change(input, { target: { value: '0130' } });
+
+      const saveButton = screen.getByTitle('保存');
+      fireEvent.click(saveButton);
+
+      expect(screen.getByText('16進数として読める偶数桁の名前は使用できません')).toBeInTheDocument();
+    });
+
+    it('should show error for alias starting with symbol', async () => {
+      render(
+        <AliasEditor
+          device={mockDevice}
+          currentAlias={undefined}
+          onAddAlias={mockOnAddAlias}
+          onDeleteAlias={mockOnDeleteAlias}
+        />
+      );
+
+      const addButton = screen.getByTitle('エイリアスを追加');
+      fireEvent.click(addButton);
+
+      const input = screen.getByPlaceholderText('エイリアス名を入力');
+      fireEvent.change(input, { target: { value: '@group' } });
+
+      const saveButton = screen.getByTitle('保存');
+      fireEvent.click(saveButton);
+
+      expect(screen.getByText('記号で始まる名前は使用できません')).toBeInTheDocument();
+    });
+  });
+
+  describe('successful operations', () => {
+    it('should call onAddAlias with valid new alias', async () => {
+      render(
+        <AliasEditor
+          device={mockDevice}
+          currentAlias={undefined}
+          onAddAlias={mockOnAddAlias}
+          onDeleteAlias={mockOnDeleteAlias}
+        />
+      );
+
+      const addButton = screen.getByTitle('エイリアスを追加');
+      fireEvent.click(addButton);
+
+      const input = screen.getByPlaceholderText('エイリアス名を入力');
+      fireEvent.change(input, { target: { value: 'kitchen_ac' } });
+
+      const saveButton = screen.getByTitle('保存');
+      fireEvent.click(saveButton);
+
+      await waitFor(() => {
+        expect(mockOnAddAlias).toHaveBeenCalledWith('kitchen_ac', mockDevice.id);
+      });
+    });
+
+    it('should call onAddAlias when updating existing alias', async () => {
+      render(
+        <AliasEditor
+          device={mockDevice}
+          currentAlias="living_ac"
+          onAddAlias={mockOnAddAlias}
+          onDeleteAlias={mockOnDeleteAlias}
+        />
+      );
+
+      const editButton = screen.getByTitle('エイリアスを編集');
+      fireEvent.click(editButton);
+
+      const input = screen.getByDisplayValue('living_ac');
+      fireEvent.change(input, { target: { value: 'bedroom_ac' } });
+
+      const saveButton = screen.getByTitle('保存');
+      fireEvent.click(saveButton);
+
+      await waitFor(() => {
+        expect(mockOnDeleteAlias).toHaveBeenCalledWith('living_ac');
+        expect(mockOnAddAlias).toHaveBeenCalledWith('bedroom_ac', mockDevice.id);
+      });
+    });
+
+    it('should exit edit mode on cancel', () => {
+      render(
+        <AliasEditor
+          device={mockDevice}
+          currentAlias="living_ac"
+          onAddAlias={mockOnAddAlias}
+          onDeleteAlias={mockOnDeleteAlias}
+        />
+      );
+
+      const editButton = screen.getByTitle('エイリアスを編集');
+      fireEvent.click(editButton);
+
+      const cancelButton = screen.getByTitle('キャンセル');
+      fireEvent.click(cancelButton);
+
+      expect(screen.getByText('living_ac')).toBeInTheDocument();
+      expect(screen.queryByPlaceholderText('エイリアス名を入力')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('loading state', () => {
+    it('should disable buttons when loading', () => {
+      render(
+        <AliasEditor
+          device={mockDevice}
+          currentAlias="living_ac"
+          onAddAlias={mockOnAddAlias}
+          onDeleteAlias={mockOnDeleteAlias}
+          isLoading={true}
+        />
+      );
+
+      expect(screen.getByTitle('エイリアスを編集')).toBeDisabled();
+      expect(screen.getByTitle('エイリアスを削除')).toBeDisabled();
+    });
+  });
+});

--- a/web/src/components/AliasEditor.tsx
+++ b/web/src/components/AliasEditor.tsx
@@ -1,0 +1,187 @@
+import { useState, useRef, useEffect } from 'react';
+import { Edit2, Trash2, Plus, Check, X } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Badge } from '@/components/ui/badge';
+import { validateDeviceAlias } from '@/libs/aliasHelper';
+import type { Device } from '@/hooks/types';
+
+interface AliasEditorProps {
+  device: Device;
+  currentAlias?: string;
+  onAddAlias: (alias: string, target: string) => Promise<void>;
+  onDeleteAlias: (alias: string) => Promise<void>;
+  isLoading?: boolean;
+}
+
+export function AliasEditor({
+  device,
+  currentAlias,
+  onAddAlias,
+  onDeleteAlias,
+  isLoading = false
+}: AliasEditorProps) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [inputValue, setInputValue] = useState(currentAlias || '');
+  const [error, setError] = useState<string | undefined>();
+  const [isSaving, setIsSaving] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Focus input when entering edit mode
+  useEffect(() => {
+    if (isEditing && inputRef.current) {
+      inputRef.current.focus();
+      // Select all text for easy replacement
+      inputRef.current.select();
+    }
+  }, [isEditing]);
+
+  const handleStartEdit = () => {
+    setIsEditing(true);
+    setInputValue(currentAlias || '');
+    setError(undefined);
+  };
+
+  const handleCancel = () => {
+    setIsEditing(false);
+    setInputValue(currentAlias || '');
+    setError(undefined);
+  };
+
+  const handleSave = async () => {
+    const validationError = validateDeviceAlias(inputValue);
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+
+    if (!device.id) {
+      setError('デバイスIDが取得できません');
+      return;
+    }
+
+    setIsSaving(true);
+    try {
+      // If updating existing alias, delete old one first
+      if (currentAlias && currentAlias !== inputValue) {
+        await onDeleteAlias(currentAlias);
+      }
+      
+      // Add the new alias
+      await onAddAlias(inputValue, device.id);
+      
+      setIsEditing(false);
+      setError(undefined);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'エイリアスの保存に失敗しました');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!currentAlias) return;
+    
+    setIsSaving(true);
+    try {
+      await onDeleteAlias(currentAlias);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'エイリアスの削除に失敗しました');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  if (isEditing) {
+    return (
+      <div className="space-y-2">
+        <div className="flex items-center gap-2">
+          <Input
+            ref={inputRef}
+            value={inputValue}
+            onChange={(e) => {
+              setInputValue(e.target.value);
+              setError(undefined);
+            }}
+            placeholder="エイリアス名を入力"
+            className="h-7 text-xs flex-1"
+            disabled={isSaving}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                handleSave();
+              } else if (e.key === 'Escape') {
+                handleCancel();
+              }
+            }}
+          />
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleSave}
+            disabled={isSaving}
+            className="h-7 w-7 p-0"
+            title="保存"
+          >
+            <Check className="h-3 w-3" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleCancel}
+            disabled={isSaving}
+            className="h-7 w-7 p-0"
+            title="キャンセル"
+          >
+            <X className="h-3 w-3" />
+          </Button>
+        </div>
+        {error && (
+          <p className="text-xs text-destructive">{error}</p>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      {currentAlias ? (
+        <>
+          <Badge variant="secondary" className="text-xs px-2 py-0.5">
+            {currentAlias}
+          </Badge>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleStartEdit}
+            disabled={isLoading || isSaving}
+            className="h-6 w-6 p-0"
+            title="エイリアスを編集"
+          >
+            <Edit2 className="h-3 w-3" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleDelete}
+            disabled={isLoading || isSaving}
+            className="h-6 w-6 p-0"
+            title="エイリアスを削除"
+          >
+            <Trash2 className="h-3 w-3" />
+          </Button>
+        </>
+      ) : (
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={handleStartEdit}
+          disabled={isLoading || isSaving}
+          className="h-6 w-6 p-0"
+          title="エイリアスを追加"
+        >
+          <Plus className="h-3 w-3" />
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/DeviceCard.tsx
+++ b/web/src/components/DeviceCard.tsx
@@ -4,6 +4,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { PropertyEditor } from '@/components/PropertyEditor';
+import { AliasEditor } from '@/components/AliasEditor';
 import { DeviceStatusIndicators } from '@/components/DeviceStatusIndicators';
 import { getPropertyName, formatPropertyValueWithTranslation, getPropertyDescriptor, isPropertySettable, shouldShowHexViewer, edtToHexString } from '@/libs/propertyHelper';
 import { translateLocationId } from '@/libs/locationHelper';
@@ -22,6 +23,9 @@ interface DeviceCardProps {
   getDeviceClassCode: (device: Device) => string;
   devices: Record<string, Device>;
   aliases: Record<string, string>;
+  onAddAlias?: (alias: string, target: string) => Promise<void>;
+  onDeleteAlias?: (alias: string) => Promise<void>;
+  isAliasLoading?: boolean;
 }
 
 export function DeviceCard({
@@ -34,7 +38,10 @@ export function DeviceCard({
   propertyDescriptions,
   getDeviceClassCode,
   devices,
-  aliases
+  aliases,
+  onAddAlias,
+  onDeleteAlias,
+  isAliasLoading = false
 }: DeviceCardProps) {
   const aliasInfo = deviceHasAlias(device, devices, aliases);
   const classCode = getDeviceClassCode(device);
@@ -167,9 +174,22 @@ export function DeviceCard({
               </p>
             )}
             {isExpanded && (
-              <p className="text-xs text-muted-foreground">
-                {device.ip} - {device.eoj}
-              </p>
+              <>
+                <p className="text-xs text-muted-foreground">
+                  {device.ip} - {device.eoj}
+                </p>
+                {onAddAlias && onDeleteAlias && (
+                  <div className="mt-2">
+                    <AliasEditor
+                      device={device}
+                      currentAlias={aliasInfo.aliasName}
+                      onAddAlias={onAddAlias}
+                      onDeleteAlias={onDeleteAlias}
+                      isLoading={isAliasLoading}
+                    />
+                  </div>
+                )}
+              </>
             )}
           </div>
           <div className="flex items-center gap-1 shrink-0">

--- a/web/src/libs/aliasHelper.test.ts
+++ b/web/src/libs/aliasHelper.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { validateDeviceAlias } from './aliasHelper';
+
+describe('validateDeviceAlias', () => {
+  describe('valid aliases', () => {
+    it('should accept simple alphanumeric aliases', () => {
+      expect(validateDeviceAlias('kitchen_ac')).toBeUndefined();
+      expect(validateDeviceAlias('AC1')).toBeUndefined();
+      expect(validateDeviceAlias('living-room')).toBeUndefined();
+      expect(validateDeviceAlias('エアコン1')).toBeUndefined();
+    });
+
+    it('should accept aliases starting with letters', () => {
+      expect(validateDeviceAlias('ac123')).toBeUndefined();
+      expect(validateDeviceAlias('test')).toBeUndefined();
+    });
+
+    it('should accept aliases starting with numbers', () => {
+      expect(validateDeviceAlias('1st_floor_ac')).toBeUndefined();
+      expect(validateDeviceAlias('2ndRoom')).toBeUndefined();
+    });
+
+    it('should accept odd-length hex strings', () => {
+      expect(validateDeviceAlias('ABC')).toBeUndefined(); // 3 chars
+      expect(validateDeviceAlias('12345')).toBeUndefined(); // 5 chars
+    });
+  });
+
+  describe('invalid aliases', () => {
+    it('should reject empty string', () => {
+      expect(validateDeviceAlias('')).toBe('エイリアス名を入力してください');
+    });
+
+    it('should reject even-length hex strings', () => {
+      expect(validateDeviceAlias('80')).toBe('16進数として読める偶数桁の名前は使用できません');
+      expect(validateDeviceAlias('0130')).toBe('16進数として読める偶数桁の名前は使用できません');
+      expect(validateDeviceAlias('ABCD')).toBe('16進数として読める偶数桁の名前は使用できません');
+      expect(validateDeviceAlias('1234567890ABCDEF')).toBe('16進数として読める偶数桁の名前は使用できません');
+    });
+
+    it('should reject aliases starting with symbols', () => {
+      expect(validateDeviceAlias('!test')).toBe('記号で始まる名前は使用できません');
+      expect(validateDeviceAlias('@group')).toBe('記号で始まる名前は使用できません');
+      expect(validateDeviceAlias('#tag')).toBe('記号で始まる名前は使用できません');
+      expect(validateDeviceAlias('-dash')).toBe('記号で始まる名前は使用できません');
+      expect(validateDeviceAlias('[bracket')).toBe('記号で始まる名前は使用できません');
+      expect(validateDeviceAlias('{brace')).toBe('記号で始まる名前は使用できません');
+    });
+
+    it('should allow symbols in the middle or end', () => {
+      expect(validateDeviceAlias('test-name')).toBeUndefined();
+      expect(validateDeviceAlias('test_name')).toBeUndefined();
+      expect(validateDeviceAlias('test!')).toBeUndefined();
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle mixed case hex strings', () => {
+      expect(validateDeviceAlias('aB')).toBe('16進数として読める偶数桁の名前は使用できません');
+      expect(validateDeviceAlias('aBc')).toBeUndefined(); // odd length
+    });
+
+    it('should handle non-hex even-length strings', () => {
+      expect(validateDeviceAlias('GH')).toBeUndefined(); // contains non-hex char
+      expect(validateDeviceAlias('test')).toBeUndefined(); // contains non-hex chars
+    });
+
+    it('should handle Unicode characters', () => {
+      expect(validateDeviceAlias('エアコン')).toBeUndefined();
+      expect(validateDeviceAlias('🏠room')).toBe('記号で始まる名前は使用できません'); // emoji is considered a symbol
+    });
+  });
+});

--- a/web/src/libs/aliasHelper.ts
+++ b/web/src/libs/aliasHelper.ts
@@ -1,0 +1,32 @@
+/**
+ * Validates a device alias according to the same rules as the server.
+ * @param alias The alias to validate
+ * @returns Error message if invalid, undefined if valid
+ */
+export function validateDeviceAlias(alias: string): string | undefined {
+  // Empty string is not allowed
+  if (alias === '') {
+    return 'エイリアス名を入力してください';
+  }
+
+  // Check if it's an even-length hex string
+  const hexPattern = /^[0-9A-Fa-f]+$/;
+  if (alias.length % 2 === 0 && alias.length > 0 && hexPattern.test(alias)) {
+    return '16進数として読める偶数桁の名前は使用できません';
+  }
+
+  // Check if it starts with a symbol
+  const invalidFirstCharPattern = /^[!"#$%&'()*+,./:;<=>?@[\\\]^_{|}~-]/;
+  if (invalidFirstCharPattern.test(alias)) {
+    return '記号で始まる名前は使用できません';
+  }
+
+  // Check for emojis at the start (they are considered symbols)
+  // This is a simplified check - emojis are in various Unicode ranges
+  const emojiPattern = /^[\u{1F300}-\u{1F9FF}\u{1F600}-\u{1F64F}\u{1F680}-\u{1F6FF}\u{2600}-\u{26FF}\u{2700}-\u{27BF}]/u;
+  if (emojiPattern.test(alias)) {
+    return '記号で始まる名前は使用できません';
+  }
+
+  return undefined;
+}


### PR DESCRIPTION
## Summary
Web UIにデバイスエイリアスの編集機能を追加しました。Issue #54で要望されていた機能です。

## Test plan
- [x] AliasEditorコンポーネントのユニットテスト（12テスト）
- [x] aliasHelperのユニットテスト（11テスト）
- [x] ビルド成功確認
- [x] ESLint警告なし
- [x] TypeScript型チェック通過

### 手動テスト手順
1. `./echonet-list -websocket` でサーバー起動
2. ブラウザでWeb UIにアクセス
3. デバイスカードを展開
4. エイリアス追加・編集・削除を確認

## Changes
### ✨ 新機能
- **AliasEditor**: エイリアスの追加・編集・削除UIコンポーネント
  - インライン編集モード
  - 自動フォーカス機能
  - キーボードショートカット（Enter保存、Escape キャンセル）
  - 適切なエラーメッセージ表示

- **aliasHelper**: エイリアス名検証ロジック
  - サーバー側と同じ検証ルールを実装
  - 空文字列、偶数桁16進数、記号開始の禁止

### 🔧 変更
- **DeviceCard**: 展開時にAliasEditorを表示
- **App.tsx**: エイリアス管理ハンドラーとローディング状態を追加

### 🧪 テスト
- AliasEditor: 12テストケース（表示、編集、検証、操作）
- aliasHelper: 11テストケース（有効・無効パターン、エッジケース）

🤖 Generated with [Claude Code](https://claude.ai/code)