### PR TITLE
feat: Page Visibility APIによるWebSocketの自動切断・再接続機能を追加

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -51,10 +51,11 @@ function App() {
   });
   const cardExpansion = useCardExpansion();
   
-  // Auto-reconnect when page/browser becomes active
+  // Auto-reconnect when page/browser becomes active and auto-disconnect when hidden
   useAutoReconnect({
     connectionState: echonet.connectionState,
     connect: echonet.connect,
+    disconnect: echonet.disconnect,
   });
   
   // Loading state for update operations

--- a/web/src/hooks/useAutoReconnect.test.ts
+++ b/web/src/hooks/useAutoReconnect.test.ts
@@ -1,0 +1,214 @@
+import { renderHook } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { useAutoReconnect } from './useAutoReconnect';
+
+describe('useAutoReconnect', () => {
+  let mockConnect: ReturnType<typeof vi.fn>;
+  let mockDisconnect: ReturnType<typeof vi.fn>;
+  let mockAddEventListener: ReturnType<typeof vi.fn>;
+  let mockRemoveEventListener: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockConnect = vi.fn();
+    mockDisconnect = vi.fn();
+    mockAddEventListener = vi.fn();
+    mockRemoveEventListener = vi.fn();
+
+    // Mock document and window event listeners
+    Object.defineProperty(document, 'addEventListener', {
+      value: mockAddEventListener,
+      writable: true,
+    });
+    Object.defineProperty(document, 'removeEventListener', {
+      value: mockRemoveEventListener,
+      writable: true,
+    });
+    Object.defineProperty(window, 'addEventListener', {
+      value: mockAddEventListener,
+      writable: true,
+    });
+    Object.defineProperty(window, 'removeEventListener', {
+      value: mockRemoveEventListener,
+      writable: true,
+    });
+
+    // Mock document.hidden as visible by default
+    Object.defineProperty(document, 'hidden', {
+      value: false,
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should set up event listeners on mount', () => {
+    const { unmount } = renderHook(() =>
+      useAutoReconnect({
+        connectionState: 'disconnected',
+        connect: mockConnect,
+        disconnect: mockDisconnect,
+      })
+    );
+
+    expect(mockAddEventListener).toHaveBeenCalledWith('visibilitychange', expect.any(Function));
+    expect(mockAddEventListener).toHaveBeenCalledWith('focus', expect.any(Function));
+
+    unmount();
+
+    expect(mockRemoveEventListener).toHaveBeenCalledWith('visibilitychange', expect.any(Function));
+    expect(mockRemoveEventListener).toHaveBeenCalledWith('focus', expect.any(Function));
+  });
+
+  it('should disconnect when page becomes hidden and autoDisconnect is enabled', () => {
+    renderHook(() =>
+      useAutoReconnect({
+        connectionState: 'connected',
+        connect: mockConnect,
+        disconnect: mockDisconnect,
+        autoDisconnect: true,
+      })
+    );
+
+    // Get the visibilitychange handler
+    const visibilityChangeHandler = mockAddEventListener.mock.calls.find(
+      (call) => call[0] === 'visibilitychange'
+    )?.[1];
+
+    expect(visibilityChangeHandler).toBeDefined();
+
+    // Simulate page becoming hidden
+    Object.defineProperty(document, 'hidden', { value: true, writable: true });
+    visibilityChangeHandler();
+
+    expect(mockDisconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not disconnect when page becomes hidden and autoDisconnect is disabled', () => {
+    renderHook(() =>
+      useAutoReconnect({
+        connectionState: 'connected',
+        connect: mockConnect,
+        disconnect: mockDisconnect,
+        autoDisconnect: false,
+      })
+    );
+
+    // Get the visibilitychange handler
+    const visibilityChangeHandler = mockAddEventListener.mock.calls.find(
+      (call) => call[0] === 'visibilitychange'
+    )?.[1];
+
+    expect(visibilityChangeHandler).toBeDefined();
+
+    // Simulate page becoming hidden
+    Object.defineProperty(document, 'hidden', { value: true, writable: true });
+    visibilityChangeHandler();
+
+    expect(mockDisconnect).not.toHaveBeenCalled();
+  });
+
+  it('should not disconnect when page becomes hidden but connection is not connected', () => {
+    renderHook(() =>
+      useAutoReconnect({
+        connectionState: 'disconnected',
+        connect: mockConnect,
+        disconnect: mockDisconnect,
+        autoDisconnect: true,
+      })
+    );
+
+    // Get the visibilitychange handler
+    const visibilityChangeHandler = mockAddEventListener.mock.calls.find(
+      (call) => call[0] === 'visibilitychange'
+    )?.[1];
+
+    expect(visibilityChangeHandler).toBeDefined();
+
+    // Simulate page becoming hidden
+    Object.defineProperty(document, 'hidden', { value: true, writable: true });
+    visibilityChangeHandler();
+
+    expect(mockDisconnect).not.toHaveBeenCalled();
+  });
+
+  it('should attempt reconnection when page becomes visible and connection is disconnected', () => {
+    renderHook(() =>
+      useAutoReconnect({
+        connectionState: 'disconnected',
+        connect: mockConnect,
+        disconnect: mockDisconnect,
+      })
+    );
+
+    // Get the visibilitychange handler
+    const visibilityChangeHandler = mockAddEventListener.mock.calls.find(
+      (call) => call[0] === 'visibilitychange'
+    )?.[1];
+
+    expect(visibilityChangeHandler).toBeDefined();
+
+    // Simulate page becoming visible
+    Object.defineProperty(document, 'hidden', { value: false, writable: true });
+    visibilityChangeHandler();
+
+    expect(mockConnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not attempt reconnection when page becomes visible but connection is already connected', () => {
+    renderHook(() =>
+      useAutoReconnect({
+        connectionState: 'connected',
+        connect: mockConnect,
+        disconnect: mockDisconnect,
+      })
+    );
+
+    // Get the visibilitychange handler
+    const visibilityChangeHandler = mockAddEventListener.mock.calls.find(
+      (call) => call[0] === 'visibilitychange'
+    )?.[1];
+
+    expect(visibilityChangeHandler).toBeDefined();
+
+    // Simulate page becoming visible
+    Object.defineProperty(document, 'hidden', { value: false, writable: true });
+    visibilityChangeHandler();
+
+    expect(mockConnect).not.toHaveBeenCalled();
+  });
+
+  it('should attempt reconnection on window focus when disconnected', () => {
+    renderHook(() =>
+      useAutoReconnect({
+        connectionState: 'disconnected',
+        connect: mockConnect,
+        disconnect: mockDisconnect,
+      })
+    );
+
+    // Get the window focus handler
+    const focusHandler = mockAddEventListener.mock.calls.find(
+      (call) => call[0] === 'focus'
+    )?.[1];
+
+    expect(focusHandler).toBeDefined();
+    focusHandler();
+
+    expect(mockConnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('should use default values for optional parameters', () => {
+    const { unmount } = renderHook(() =>
+      useAutoReconnect({
+        connectionState: 'disconnected',
+        connect: mockConnect,
+        disconnect: mockDisconnect,
+      })
+    );
+
+    // Should not throw an error and should work with defaults
+    expect(() => unmount()).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- Page Visibility APIを使用してページが非アクティブ時にWebSocket接続を自動切断
- ページがアクティブになった時の自動再接続機能を強化
- バッテリー消費とネットワーク使用量の最適化

## 実装内容
- `useAutoReconnect`フックを拡張してページvisibility状態に応じた接続管理を実装
- `autoDisconnect`オプション追加（デフォルト: `true`）
- ページが`hidden`になった時に接続中のWebSocketを自動切断
- ページが`visible`になった時の既存自動再接続機能を維持

## テスト
- 自動切断・再接続機能のテストケースを追加
- 既存機能の動作確認
- lint・build通過確認

## Test plan
- [x] ページを非アクティブにした時にWebSocket接続が切断されることを確認
- [x] ページをアクティブにした時にWebSocket接続が自動復旧することを確認
- [x] 複数タブ間での切り替え時の動作確認
- [ ] モバイルブラウザでのバックグラウンド・フォアグラウンド切り替え確認

🤖 Generated with [Claude Code](https://claude.ai/code)