### PR TITLE
fix: WebSocketのclose code 1005を正常な切断として扱うように修正

### DIFF
--- a/server/transport.go
+++ b/server/transport.go
@@ -311,7 +311,7 @@ func (t *DefaultWebSocketTransport) handleWebSocket(w http.ResponseWriter, r *ht
 	for {
 		_, message, err := conn.ReadMessage()
 		if err != nil {
-			if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseAbnormalClosure) {
+			if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseAbnormalClosure, websocket.CloseNoStatusReceived) {
 				slog.Error("Unexpected WebSocket close error", "err", err)
 			}
 			break


### PR DESCRIPTION
## Summary
Page Visibility APIによる自動切断時に発生するclose code 1005を正常な切断として扱い、不要なエラーログを削減する修正。

## 問題
- Page Visibility APIによるWebSocket自動切断でclose code 1005 (`CloseNoStatusReceived`)が発生
- サーバー側で「Unexpected WebSocket close error」としてERRORレベルでログ出力
- 正常な切断なのでエラーとして記録する必要がない

## 修正内容
- `server/transport.go`の`IsUnexpectedCloseError`に`websocket.CloseNoStatusReceived`を追加
- 他の箇所（SendMessage、BroadcastMessage）では既に同様の処理済みなので一貫性を保つ

## Before
```go
if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseAbnormalClosure) {
    slog.Error("Unexpected WebSocket close error", "err", err)
}
```

## After  
```go
if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseAbnormalClosure, websocket.CloseNoStatusReceived) {
    slog.Error("Unexpected WebSocket close error", "err", err)
}
```

## Test plan
- [x] Page Visibility APIによる自動切断時にエラーログが出力されないことを確認
- [ ] 本当に予期しない切断（ネットワーク障害など）ではエラーログが出力されることを確認
- [ ] 正常な切断処理は引き続き動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)