### PR TITLE
feat: Disable all editing operations when WebSocket is disconnected

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -51,6 +51,9 @@ function App() {
   });
   const cardExpansion = useCardExpansion();
   
+  // Compute isConnected from connectionState to avoid unnecessary re-renders
+  const isConnected = echonet.connectionState === 'connected';
+  
   // Auto-reconnect when page/browser becomes active and auto-disconnect when hidden
   useAutoReconnect({
     connectionState: echonet.connectionState,
@@ -465,6 +468,7 @@ function App() {
                         onAddAlias={handleAddAlias}
                         onDeleteAlias={handleDeleteAlias}
                         isAliasLoading={aliasLoading}
+                        isConnected={isConnected}
                       />
                     );
                   })}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -357,7 +357,7 @@ function App() {
                   setNewGroupTabName(tempTabName);
                   setIsCreatingGroup(true);
                 }}
-                disabled={isCreatingGroup}
+                disabled={isCreatingGroup || !isConnected}
                 className="h-8 px-2 sm:px-3 text-xs sm:text-sm"
                 data-testid="add-group-button"
               >
@@ -384,6 +384,7 @@ function App() {
                           selectTab('All');
                         }}
                         isLoading={false}
+                        isConnected={isConnected}
                       />
                     </CardContent>
                   </Card>
@@ -404,6 +405,7 @@ function App() {
                         setPendingGroupName(null);
                       }
                     }}
+                    isConnected={isConnected}
                   />
                 )}
                 
@@ -417,6 +419,7 @@ function App() {
                         onSave={(newName) => handleRenameGroup(tabId, newName)}
                         onCancel={() => setEditingGroupName(null)}
                         isLoading={groupOperationLoading}
+                        isConnected={isConnected}
                       />
                     </CardContent>
                   </Card>
@@ -446,6 +449,7 @@ function App() {
                       setEditingGroupMembers(null);
                       setPendingGroupName(null);
                     } : undefined}
+                    isConnected={isConnected}
                   />
                 ) : tabId !== newGroupTabName && (
                   <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-6 gap-3 sm:gap-4">

--- a/web/src/components/AliasEditor.test.tsx
+++ b/web/src/components/AliasEditor.test.tsx
@@ -458,4 +458,78 @@ describe('AliasEditor', () => {
       });
     });
   });
+
+  describe('WebSocket connection state', () => {
+    it('should disable all buttons when disconnected', () => {
+      render(
+        <AliasEditor
+          device={mockDevice}
+          aliases={['living_ac']}
+          onAddAlias={mockOnAddAlias}
+          onDeleteAlias={mockOnDeleteAlias}
+          deviceIdentifier="013001:00000B:ABCDEF0123456789ABCDEF012345"
+          isConnected={false}
+        />
+      );
+
+      // Edit button should be disabled
+      const editButton = screen.getByTitle('エイリアスを編集');
+      expect(editButton).toBeDisabled();
+      
+      // Delete button should be disabled
+      const deleteButton = screen.getByTitle('エイリアスを削除');
+      expect(deleteButton).toBeDisabled();
+      
+      // Add button should be disabled
+      const addButton = screen.getByTitle('エイリアスを追加');
+      expect(addButton).toBeDisabled();
+    });
+
+    it('should enable all buttons when connected', () => {
+      render(
+        <AliasEditor
+          device={mockDevice}
+          aliases={['living_ac']}
+          onAddAlias={mockOnAddAlias}
+          onDeleteAlias={mockOnDeleteAlias}
+          deviceIdentifier="013001:00000B:ABCDEF0123456789ABCDEF012345"
+          isConnected={true}
+        />
+      );
+
+      // Edit button should be enabled
+      const editButton = screen.getByTitle('エイリアスを編集');
+      expect(editButton).not.toBeDisabled();
+      
+      // Delete button should be enabled
+      const deleteButton = screen.getByTitle('エイリアスを削除');
+      expect(deleteButton).not.toBeDisabled();
+      
+      // Add button should be enabled
+      const addButton = screen.getByTitle('エイリアスを追加');
+      expect(addButton).not.toBeDisabled();
+    });
+
+    it('should default to connected when isConnected is not specified', () => {
+      render(
+        <AliasEditor
+          device={mockDevice}
+          aliases={['living_ac']}
+          onAddAlias={mockOnAddAlias}
+          onDeleteAlias={mockOnDeleteAlias}
+          deviceIdentifier="013001:00000B:ABCDEF0123456789ABCDEF012345"
+        />
+      );
+
+      // All buttons should be enabled by default
+      const editButton = screen.getByTitle('エイリアスを編集');
+      expect(editButton).not.toBeDisabled();
+      
+      const deleteButton = screen.getByTitle('エイリアスを削除');
+      expect(deleteButton).not.toBeDisabled();
+      
+      const addButton = screen.getByTitle('エイリアスを追加');
+      expect(addButton).not.toBeDisabled();
+    });
+  });
 });

--- a/web/src/components/AliasEditor.tsx
+++ b/web/src/components/AliasEditor.tsx
@@ -12,6 +12,7 @@ interface AliasEditorProps {
   onDeleteAlias: (alias: string) => Promise<void>;
   isLoading?: boolean;
   deviceIdentifier: string;
+  isConnected?: boolean;
 }
 
 export function AliasEditor({
@@ -20,7 +21,8 @@ export function AliasEditor({
   onAddAlias,
   onDeleteAlias,
   isLoading = false,
-  deviceIdentifier
+  deviceIdentifier,
+  isConnected = true
 }: AliasEditorProps) {
   const [editingIndex, setEditingIndex] = useState<number | null>(null); // null means not editing, -1 means adding new alias, >=0 means editing existing
   const [inputValue, setInputValue] = useState('');
@@ -187,7 +189,7 @@ export function AliasEditor({
               variant="ghost"
               size="sm"
               onClick={() => handleStartEdit(index)}
-              disabled={isLoading || savingIndex !== null}
+              disabled={isLoading || savingIndex !== null || !isConnected}
               className="h-6 w-6 p-0"
               title="エイリアスを編集"
             >
@@ -197,7 +199,7 @@ export function AliasEditor({
               variant="ghost"
               size="sm"
               onClick={() => handleDelete(alias, index)}
-              disabled={isLoading || savingIndex !== null}
+              disabled={isLoading || savingIndex !== null || !isConnected}
               className="h-6 w-6 p-0"
               title="エイリアスを削除"
             >
@@ -213,7 +215,7 @@ export function AliasEditor({
           variant="ghost"
           size="sm"
           onClick={handleStartAdd}
-          disabled={isLoading || savingIndex !== null}
+          disabled={isLoading || savingIndex !== null || !isConnected}
           className="h-6 w-6 p-0"
           title="エイリアスを追加"
         >

--- a/web/src/components/DeviceCard.test.tsx
+++ b/web/src/components/DeviceCard.test.tsx
@@ -324,6 +324,7 @@ describe('DeviceCard', () => {
           getDeviceClassCode={mockGetDeviceClassCode}
           devices={{ [`${mockDevice.ip} ${mockDevice.eoj}`]: mockDevice }}
           aliases={{}}
+          isConnected={true}
         />
       );
 
@@ -437,6 +438,67 @@ describe('DeviceCard', () => {
       );
 
       expect(screen.getByText(/Device:.*Single Function Lighting/)).toBeInTheDocument();
+    });
+  });
+
+  describe('WebSocket connection state', () => {
+    it('should disable update button when disconnected', () => {
+      render(
+        <DeviceCard
+          device={mockDevice}
+          isExpanded={false}
+          onToggleExpansion={vi.fn()}
+          onPropertyChange={mockOnPropertyChange}
+          onUpdateProperties={mockOnUpdateProperties}
+          propertyDescriptions={mockPropertyDescriptions}
+          getDeviceClassCode={mockGetDeviceClassCode}
+          devices={{ [`${mockDevice.ip} ${mockDevice.eoj}`]: mockDevice }}
+          aliases={{}}
+          isConnected={false}
+        />
+      );
+
+      const updateButton = screen.getByTestId('update-properties-button');
+      expect(updateButton).toBeDisabled();
+    });
+
+    it('should enable update button when connected', () => {
+      render(
+        <DeviceCard
+          device={mockDevice}
+          isExpanded={false}
+          onToggleExpansion={vi.fn()}
+          onPropertyChange={mockOnPropertyChange}
+          onUpdateProperties={mockOnUpdateProperties}
+          propertyDescriptions={mockPropertyDescriptions}
+          getDeviceClassCode={mockGetDeviceClassCode}
+          devices={{ [`${mockDevice.ip} ${mockDevice.eoj}`]: mockDevice }}
+          aliases={{}}
+          isConnected={true}
+        />
+      );
+
+      const updateButton = screen.getByTestId('update-properties-button');
+      expect(updateButton).not.toBeDisabled();
+    });
+
+    it('should default to enabled when isConnected is not specified', () => {
+      render(
+        <DeviceCard
+          device={mockDevice}
+          isExpanded={false}
+          onToggleExpansion={vi.fn()}
+          onPropertyChange={mockOnPropertyChange}
+          onUpdateProperties={mockOnUpdateProperties}
+          propertyDescriptions={mockPropertyDescriptions}
+          getDeviceClassCode={mockGetDeviceClassCode}
+          devices={{ [`${mockDevice.ip} ${mockDevice.eoj}`]: mockDevice }}
+          aliases={{}}
+        />
+      );
+
+      const updateButton = screen.getByTestId('update-properties-button');
+      expect(updateButton).not.toBeDisabled();
     });
   });
 });

--- a/web/src/components/DeviceCard.tsx
+++ b/web/src/components/DeviceCard.tsx
@@ -39,7 +39,7 @@ export function DeviceCard({
   onAddAlias,
   onDeleteAlias,
   isAliasLoading = false,
-  isConnected
+  isConnected = true
 }: DeviceCardProps) {
   const aliasInfo = deviceHasAlias(device, devices, aliases);
   const deviceAliasesInfo = getDeviceAliases(device, devices, aliases);
@@ -89,7 +89,7 @@ export function DeviceCard({
                 onClick={() => onUpdateProperties(`${device.ip} ${device.eoj}`)}
                 className="h-6 w-6 p-0"
                 title={isUpdating ? "Updating..." : "Update device properties"}
-                disabled={isUpdating}
+                disabled={isUpdating || !isConnected}
                 data-testid="update-properties-button"
               >
                 <RefreshCw className={`h-3 w-3 ${isUpdating ? 'animate-spin' : ''}`} />

--- a/web/src/components/DeviceCard.tsx
+++ b/web/src/components/DeviceCard.tsx
@@ -22,6 +22,7 @@ interface DeviceCardProps {
   onAddAlias?: (alias: string, target: string) => Promise<void>;
   onDeleteAlias?: (alias: string) => Promise<void>;
   isAliasLoading?: boolean;
+  isConnected?: boolean;
 }
 
 export function DeviceCard({
@@ -37,7 +38,8 @@ export function DeviceCard({
   aliases,
   onAddAlias,
   onDeleteAlias,
-  isAliasLoading = false
+  isAliasLoading = false,
+  isConnected
 }: DeviceCardProps) {
   const aliasInfo = deviceHasAlias(device, devices, aliases);
   const deviceAliasesInfo = getDeviceAliases(device, devices, aliases);
@@ -140,6 +142,7 @@ export function DeviceCard({
                   onPropertyChange={onPropertyChange}
                   propertyDescriptions={propertyDescriptions}
                   classCode={classCode}
+                  isConnected={isConnected}
                 />
               ))}
             </div>
@@ -162,6 +165,7 @@ export function DeviceCard({
                     onPropertyChange={onPropertyChange}
                     propertyDescriptions={propertyDescriptions}
                     classCode={classCode}
+                    isConnected={isConnected}
                   />
                 ))}
               </div>

--- a/web/src/components/DeviceCard.tsx
+++ b/web/src/components/DeviceCard.tsx
@@ -122,6 +122,7 @@ export function DeviceCard({
             onDeleteAlias={onDeleteAlias}
             isLoading={isAliasLoading}
             deviceIdentifier={deviceIdentifier}
+            isConnected={isConnected}
           />
         </div>
       )}

--- a/web/src/components/GroupManagementPanel.tsx
+++ b/web/src/components/GroupManagementPanel.tsx
@@ -10,6 +10,7 @@ interface GroupManagementPanelProps {
   onEditMembers: () => void;
   isEditingMembers?: boolean;
   onDoneEditingMembers?: () => void;
+  isConnected?: boolean;
 }
 
 export function GroupManagementPanel({
@@ -19,6 +20,7 @@ export function GroupManagementPanel({
   onEditMembers,
   isEditingMembers = false,
   onDoneEditingMembers,
+  isConnected = true,
 }: GroupManagementPanelProps) {
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 
@@ -55,6 +57,7 @@ export function GroupManagementPanel({
                 variant="outline"
                 size="sm"
                 onClick={onRename}
+                disabled={!isConnected}
                 title="グループ名を変更"
               >
                 <Edit2 className="h-4 w-4 sm:mr-2" />
@@ -65,6 +68,7 @@ export function GroupManagementPanel({
                 variant="outline"
                 size="sm"
                 onClick={onEditMembers}
+                disabled={!isConnected}
                 title="メンバーを編集"
               >
                 <Users className="h-4 w-4 sm:mr-2" />
@@ -76,6 +80,7 @@ export function GroupManagementPanel({
                 size="sm"
                 className="destructive"
                 onClick={handleDeleteClick}
+                disabled={!isConnected}
                 title="グループを削除"
               >
                 <Trash2 className="h-4 w-4 sm:mr-2" />

--- a/web/src/components/GroupMemberEditor.tsx
+++ b/web/src/components/GroupMemberEditor.tsx
@@ -19,6 +19,7 @@ interface GroupMemberEditorProps {
   getDeviceClassCode: (device: Device) => string;
   isLoading?: boolean;
   onDone?: () => void;
+  isConnected?: boolean;
 }
 
 export function GroupMemberEditor({
@@ -32,6 +33,7 @@ export function GroupMemberEditor({
   getDeviceClassCode,
   isLoading = false,
   onDone,
+  isConnected = true,
 }: GroupMemberEditorProps) {
   const [dragOverSection, setDragOverSection] = useState<'members' | 'available' | null>(null);
   const [draggingDevice, setDraggingDevice] = useState<string | null>(null);
@@ -244,7 +246,7 @@ export function GroupMemberEditor({
                   variant="outline"
                   size="sm"
                   onClick={() => handleRemoveDevice(deviceKey)}
-                  disabled={isLoading}
+                  disabled={isLoading || !isConnected}
                   className="h-8 w-8 p-0"
                   title="グループから削除"
                   data-testid={`remove-device-${deviceKey.replace(/\s+/g, '-')}`}
@@ -256,7 +258,7 @@ export function GroupMemberEditor({
                   variant="outline"
                   size="sm"
                   onClick={() => handleAddDevice(deviceKey)}
-                  disabled={isLoading}
+                  disabled={isLoading || !isConnected}
                   className="h-8 w-8 p-0"
                   title="グループに追加"
                   data-testid={`add-device-${deviceKey.replace(/\s+/g, '-')}`}
@@ -281,7 +283,7 @@ export function GroupMemberEditor({
               variant="outline"
               size="sm"
               onClick={onDone}
-              disabled={isLoading}
+              disabled={isLoading || !isConnected}
               title="メンバー編集を終了"
               data-testid="done-editing-button"
             >

--- a/web/src/components/GroupNameEditor.tsx
+++ b/web/src/components/GroupNameEditor.tsx
@@ -10,6 +10,7 @@ interface GroupNameEditorProps {
   onSave: (groupName: string) => void;
   onCancel: () => void;
   isLoading?: boolean;
+  isConnected?: boolean;
 }
 
 export function GroupNameEditor({
@@ -18,6 +19,7 @@ export function GroupNameEditor({
   onSave,
   onCancel,
   isLoading = false,
+  isConnected = true,
 }: GroupNameEditorProps) {
   // Remove '@' prefix from initial value if present
   const [inputValue, setInputValue] = useState(groupName.startsWith('@') ? groupName.slice(1) : groupName);
@@ -50,8 +52,8 @@ export function GroupNameEditor({
   };
 
   const getIsSaveDisabled = () => {
-    // Disabled while loading
-    if (isLoading) return true;
+    // Disabled while loading or disconnected
+    if (isLoading || !isConnected) return true;
     
     // Check validation with '@' prefix
     const fullGroupName = '@' + inputValue;
@@ -92,7 +94,7 @@ export function GroupNameEditor({
             onChange={handleInputChange}
             placeholder="グループ名を入力"
             className="h-7 text-xs flex-1"
-            disabled={isLoading}
+            disabled={isLoading || !isConnected}
             onCompositionStart={() => setIsComposing(true)}
             onCompositionEnd={() => setIsComposing(false)}
             onKeyDown={handleKeyDown}
@@ -113,7 +115,7 @@ export function GroupNameEditor({
             variant="ghost"
             size="sm"
             onClick={onCancel}
-            disabled={isLoading}
+            disabled={isLoading || !isConnected}
             className="h-7 w-7 p-0"
             title="キャンセル"
           >

--- a/web/src/components/PropertyEditor.test.tsx
+++ b/web/src/components/PropertyEditor.test.tsx
@@ -138,6 +138,42 @@ describe('PropertyEditor', () => {
       expect(switchElement).not.toBeDisabled();
     });
 
+    it('should show as read-only when WebSocket is disconnected', () => {
+      render(
+        <PropertyEditor
+          device={mockDevice}
+          epc="80"
+          currentValue={{ string: 'on' }}
+          descriptor={operationStatusDescriptor}
+          onPropertyChange={mockOnPropertyChange}
+          propertyDescriptions={mockPropertyDescriptions}
+          isConnected={false}
+        />
+      );
+
+      // Should not have switch control when disconnected
+      expect(screen.queryByTestId('operation-status-switch-80')).not.toBeInTheDocument();
+      // Should display the value as read-only
+      expect(screen.getByText('on')).toBeInTheDocument();
+    });
+
+    it('should enable switch when WebSocket is connected', () => {
+      render(
+        <PropertyEditor
+          device={mockDevice}
+          epc="80"
+          currentValue={{ string: 'on' }}
+          descriptor={operationStatusDescriptor}
+          onPropertyChange={mockOnPropertyChange}
+          propertyDescriptions={mockPropertyDescriptions}
+          isConnected={true}
+        />
+      );
+
+      const switchElement = screen.getByTestId('operation-status-switch-80');
+      expect(switchElement).not.toBeDisabled();
+    });
+
     it('should not render switch for properties with more than two aliases', () => {
       const otherDescriptor: PropertyDescriptor = {
         description: 'Illuminance level',
@@ -282,6 +318,43 @@ describe('PropertyEditor', () => {
       expect(screen.queryByTestId('operation-status-switch-81')).not.toBeInTheDocument();
       expect(screen.getByTestId('alias-select-trigger-81')).toBeInTheDocument();
     });
+
+    it('should show as read-only when WebSocket is disconnected', () => {
+      const locationDescriptor: PropertyDescriptor = {
+        description: 'Installation location',
+        aliases: {
+          'living': '08',
+          'dining': '10',
+          'kitchen': '18'
+        }
+      };
+
+      const deviceWith81Settable = {
+        ...mockDevice,
+        properties: {
+          ...mockDevice.properties,
+          '81': { string: 'living' },
+          '9E': { EDT: btoa(String.fromCharCode(0x02, 0x80, 0x81)) }
+        }
+      };
+
+      render(
+        <PropertyEditor
+          device={deviceWith81Settable}
+          epc="81"
+          currentValue={{ string: 'living' }}
+          descriptor={locationDescriptor}
+          onPropertyChange={mockOnPropertyChange}
+          propertyDescriptions={mockPropertyDescriptions}
+          isConnected={false}
+        />
+      );
+
+      // Should not have dropdown when disconnected
+      expect(screen.queryByTestId('alias-select-trigger-81')).not.toBeInTheDocument();
+      // Should display the translated location as read-only
+      expect(screen.getByText('Living Room')).toBeInTheDocument();
+    });
   });
 
   describe('Slider functionality for numeric properties', () => {
@@ -330,6 +403,25 @@ describe('PropertyEditor', () => {
       expect(screen.getByText('30')).toBeInTheDocument();
       
       // Check unit display
+      expect(screen.getByText('22°C')).toBeInTheDocument();
+    });
+
+    it('should show as read-only when WebSocket is disconnected', () => {
+      render(
+        <PropertyEditor
+          device={deviceWithTemperatureSettable}
+          epc="B3"
+          currentValue={{ number: 22 }}
+          descriptor={temperatureDescriptor}
+          onPropertyChange={mockOnPropertyChange}
+          propertyDescriptions={mockPropertyDescriptions}
+          isConnected={false}
+        />
+      );
+
+      // Should not have edit button when disconnected
+      expect(screen.queryByTestId('edit-button-B3')).not.toBeInTheDocument();
+      // Should display value as read-only
       expect(screen.getByText('22°C')).toBeInTheDocument();
     });
 
@@ -412,6 +504,47 @@ describe('PropertyEditor', () => {
       
       // Should show min value on slider (0%)
       expect(screen.getByText('0%')).toBeInTheDocument();
+    });
+  });
+
+  describe('WebSocket connection state handling', () => {
+    it('should show as read-only when WebSocket is disconnected', () => {
+      const temperatureDescriptor: PropertyDescriptor = {
+        description: 'Temperature setting',
+        numberDesc: {
+          min: 16,
+          max: 30,
+          offset: 0,
+          unit: '°C',
+          edtLen: 1
+        }
+      };
+
+      const deviceWithTemperatureSettable = {
+        ...mockDevice,
+        properties: {
+          ...mockDevice.properties,
+          'B3': { number: 22 },
+          '9E': { EDT: btoa(String.fromCharCode(0x02, 0x80, 0xB3)) }
+        }
+      };
+
+      render(
+        <PropertyEditor
+          device={deviceWithTemperatureSettable}
+          epc="B3"
+          currentValue={{ number: 22 }}
+          descriptor={temperatureDescriptor}
+          onPropertyChange={mockOnPropertyChange}
+          propertyDescriptions={mockPropertyDescriptions}
+          isConnected={false}
+        />
+      );
+
+      // Should not have edit button
+      expect(screen.queryByTestId('edit-button-B3')).not.toBeInTheDocument();
+      // Should show read-only value
+      expect(screen.getByText('22°C')).toBeInTheDocument();
     });
   });
 

--- a/web/src/components/PropertyRow.tsx
+++ b/web/src/components/PropertyRow.tsx
@@ -11,6 +11,7 @@ interface PropertyRowProps {
   onPropertyChange: (target: string, epc: string, value: PropertyValue) => Promise<void>;
   propertyDescriptions: Record<string, PropertyDescriptionData>;
   classCode: string;
+  isConnected?: boolean;
 }
 
 export function PropertyRow({
@@ -20,7 +21,8 @@ export function PropertyRow({
   isCompact,
   onPropertyChange,
   propertyDescriptions,
-  classCode
+  classCode,
+  isConnected
 }: PropertyRowProps) {
   const propertyName = getPropertyName(epc, propertyDescriptions, classCode);
   const propertyDescriptor = getPropertyDescriptor(epc, propertyDescriptions, classCode);
@@ -48,6 +50,7 @@ export function PropertyRow({
                 descriptor={propertyDescriptor}
                 onPropertyChange={onPropertyChange}
                 propertyDescriptions={propertyDescriptions}
+                isConnected={isConnected}
               />
             ) : (
               <PropertyDisplay
@@ -78,6 +81,7 @@ export function PropertyRow({
             descriptor={propertyDescriptor}
             onPropertyChange={onPropertyChange}
             propertyDescriptions={propertyDescriptions}
+            isConnected={isConnected}
           />
         </div>
       </div>


### PR DESCRIPTION
## Summary
WebSocket接続が切断されている時に、すべての編集操作を無効化する機能を追加しました。

## Problem
現在、WebSocket接続が切断された状態でも編集操作（プロパティ変更、エイリアス編集、グループ管理など）が可能でしたが、これらの操作はWebSocket経由で行われるため必ず失敗し、ユーザーエクスペリエンスが悪い状態でした。

## Solution
WebSocket接続状態に基づいて、以下のすべての編集機能を無効化するようにしました：

### 🔧 プロパティ編集
- デバイスのスイッチ（on/off）操作
- ドロップダウンでの設定値変更
- 数値入力での設定変更
- デバイスプロパティの更新ボタン

### 🏷️ デバイスエイリアス管理
- エイリアスの追加
- エイリアスの編集
- エイリアスの削除

### 👥 グループ管理
- 新規グループの作成
- グループ名の変更
- グループメンバーの追加・削除
- グループの削除

## Technical Implementation
- App.tsxで`connectionState === 'connected'`を`isConnected: boolean`として計算
- 各編集コンポーネントに`isConnected`プロパティを追加
- WebSocket未接続時は編集UIを無効化または読み取り専用表示に切り替え

## Testing
- 314個のテストがすべてパス
- WebSocket接続状態に関する新しいテストケースを追加
- 型チェック・ビルド・Lintすべて成功

## User Experience
WebSocket接続が切断された場合：
- ❌ 編集操作は無効化され、クリックできません
- ✅ 現在の状態は引き続き表示されます
- ✅ 接続が復活すると、編集機能が自動的に有効化されます

これにより、ユーザーは失敗する操作を試行することがなくなり、接続状態が明確に分かるようになります。

🤖 Generated with [Claude Code](https://claude.ai/code)