### PR TITLE
feat: Add sensor icons and compact layout for temperature/humidity values

### DIFF
--- a/web/src/components/PropertyRow.tsx
+++ b/web/src/components/PropertyRow.tsx
@@ -1,6 +1,7 @@
 import { PropertyEditor } from './PropertyEditor';
 import { PropertyDisplay } from './PropertyDisplay';
 import { getPropertyName, getPropertyDescriptor, isPropertySettable } from '@/libs/propertyHelper';
+import { isSensorProperty, getSensorIcon } from '@/libs/sensorPropertyHelper';
 import type { Device, PropertyValue, PropertyDescriptionData } from '@/hooks/types';
 
 interface PropertyRowProps {
@@ -34,7 +35,42 @@ export function PropertyRow({
   const isInSetPropertyMap = propertyDescriptor && isPropertySettable(epc, device);
   const isSettable = hasEditCapability && isInSetPropertyMap;
 
+  // Check if this is a sensor property for special compact display
+  const isSensor = isSensorProperty(epc);
+  const SensorIcon = getSensorIcon(epc);
+
+  if (isCompact && isSensor && SensorIcon) {
+    // Sensor properties in compact mode: icon + value only
+    return (
+      <div className="inline-flex items-center gap-1 text-xs mr-3 mb-1" title={propertyName}>
+        <SensorIcon className="h-3 w-3 text-muted-foreground" />
+        <div>
+          {isSettable ? (
+            <PropertyEditor
+              device={device}
+              epc={epc}
+              currentValue={value}
+              descriptor={propertyDescriptor}
+              onPropertyChange={onPropertyChange}
+              propertyDescriptions={propertyDescriptions}
+              isConnected={isConnected}
+            />
+          ) : (
+            <PropertyDisplay
+              currentValue={value}
+              descriptor={propertyDescriptor}
+              epc={epc}
+              propertyDescriptions={propertyDescriptions}
+              device={device}
+            />
+          )}
+        </div>
+      </div>
+    );
+  }
+
   if (isCompact) {
+    // Non-sensor properties in compact mode: traditional label + value display
     return (
       <div className="text-xs relative">
         <div className="flex flex-wrap items-center gap-x-2 gap-y-1">

--- a/web/src/libs/sensorPropertyHelper.test.ts
+++ b/web/src/libs/sensorPropertyHelper.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import {
+  Thermometer,
+  CloudSun,
+  Home,
+  ThermometerSun,
+  ThermometerSnowflake,
+  Droplets
+} from 'lucide-react';
+import {
+  isSensorProperty,
+  getSensorIcon,
+  getSensorEPCs
+} from './sensorPropertyHelper';
+
+describe('sensorPropertyHelper', () => {
+  describe('isSensorProperty', () => {
+    it('should return true for room temperature EPCs', () => {
+      expect(isSensorProperty('BB')).toBe(true); // Air Conditioner
+      expect(isSensorProperty('E2')).toBe(true); // Floor Heating
+    });
+
+    it('should return true for outside temperature EPC', () => {
+      expect(isSensorProperty('BE')).toBe(true);
+    });
+
+    it('should return true for floor temperature EPC', () => {
+      expect(isSensorProperty('E3')).toBe(true);
+    });
+
+    it('should return true for water temperature sensor EPCs', () => {
+      expect(isSensorProperty('F3')).toBe(true); // Temperature sensor 1
+      expect(isSensorProperty('F4')).toBe(true); // Temperature sensor 2
+    });
+
+    it('should return true for humidity EPC', () => {
+      expect(isSensorProperty('BA')).toBe(true);
+    });
+
+    it('should return false for non-sensor EPCs', () => {
+      expect(isSensorProperty('80')).toBe(false); // Operation status
+      expect(isSensorProperty('B3')).toBe(false); // Temperature setting
+      expect(isSensorProperty('B4')).toBe(false); // Humidity setting
+      expect(isSensorProperty('B0')).toBe(false); // Operation mode
+      expect(isSensorProperty('XX')).toBe(false); // Unknown EPC
+    });
+  });
+
+  describe('getSensorIcon', () => {
+    it('should return Thermometer for room temperature EPCs', () => {
+      expect(getSensorIcon('BB')).toBe(Thermometer);
+      expect(getSensorIcon('E2')).toBe(Thermometer);
+    });
+
+    it('should return CloudSun for outside temperature', () => {
+      expect(getSensorIcon('BE')).toBe(CloudSun);
+    });
+
+    it('should return Home for floor temperature', () => {
+      expect(getSensorIcon('E3')).toBe(Home);
+    });
+
+    it('should return ThermometerSun for temperature sensor 1', () => {
+      expect(getSensorIcon('F3')).toBe(ThermometerSun);
+    });
+
+    it('should return ThermometerSnowflake for temperature sensor 2', () => {
+      expect(getSensorIcon('F4')).toBe(ThermometerSnowflake);
+    });
+
+    it('should return Droplets for humidity', () => {
+      expect(getSensorIcon('BA')).toBe(Droplets);
+    });
+
+    it('should return undefined for non-sensor EPCs', () => {
+      expect(getSensorIcon('80')).toBeUndefined();
+      expect(getSensorIcon('B3')).toBeUndefined();
+      expect(getSensorIcon('XX')).toBeUndefined();
+    });
+  });
+
+  describe('getSensorEPCs', () => {
+    it('should return all sensor EPCs', () => {
+      const sensorEPCs = getSensorEPCs();
+      expect(sensorEPCs).toContain('BB');
+      expect(sensorEPCs).toContain('E2');
+      expect(sensorEPCs).toContain('BE');
+      expect(sensorEPCs).toContain('E3');
+      expect(sensorEPCs).toContain('F3');
+      expect(sensorEPCs).toContain('F4');
+      expect(sensorEPCs).toContain('BA');
+      expect(sensorEPCs).toHaveLength(7);
+    });
+
+    it('should not contain non-sensor EPCs', () => {
+      const sensorEPCs = getSensorEPCs();
+      expect(sensorEPCs).not.toContain('80');
+      expect(sensorEPCs).not.toContain('B3');
+      expect(sensorEPCs).not.toContain('B4');
+    });
+  });
+});

--- a/web/src/libs/sensorPropertyHelper.ts
+++ b/web/src/libs/sensorPropertyHelper.ts
@@ -1,0 +1,53 @@
+import {
+  Thermometer,
+  CloudSun,
+  Home,
+  ThermometerSun,
+  ThermometerSnowflake,
+  Droplets,
+  type LucideIcon
+} from 'lucide-react';
+
+// Sensor property EPCs and their corresponding icons
+const SENSOR_PROPERTY_ICONS: Record<string, LucideIcon> = {
+  // Room temperature (Air Conditioner & Floor Heating)
+  'BB': Thermometer,
+  'E2': Thermometer,
+  
+  // Outside temperature (Air Conditioner)
+  'BE': CloudSun,
+  
+  // Floor temperature (Floor Heating)
+  'E3': Home,
+  
+  // Temperature sensor 1 (Floor Heating - outgoing water temp)
+  'F3': ThermometerSun,
+  
+  // Temperature sensor 2 (Floor Heating - return water temp)
+  'F4': ThermometerSnowflake,
+  
+  // Room humidity (Air Conditioner)
+  'BA': Droplets,
+};
+
+/**
+ * Checks if a property EPC is a sensor property
+ */
+export function isSensorProperty(epc: string): boolean {
+  return epc in SENSOR_PROPERTY_ICONS;
+}
+
+/**
+ * Gets the icon component for a sensor property
+ * Returns undefined if the property is not a sensor
+ */
+export function getSensorIcon(epc: string): LucideIcon | undefined {
+  return SENSOR_PROPERTY_ICONS[epc];
+}
+
+/**
+ * Gets all sensor EPCs as an array
+ */
+export function getSensorEPCs(): string[] {
+  return Object.keys(SENSOR_PROPERTY_ICONS);
+}


### PR DESCRIPTION
## Summary
- Added sensor property icons and improved compact layout for temperature/humidity sensor values
- Sensor values now display with distinctive icons and are positioned at the bottom of device cards
- Enhanced user experience with tooltips and visual distinction between sensor types

## Changes
- **New**: `sensorPropertyHelper.ts` with icon mapping for 7 sensor property types
- **Enhanced**: PropertyRow component with sensor-specific compact display
- **Improved**: DeviceCard layout positioning sensor values at bottom with separator
- **Added**: Comprehensive test coverage for new functionality

## Icon Mappings
- Room temperature (BB, E2): Thermometer
- Outside temperature (BE): CloudSun  
- Floor temperature (E3): Home
- Water temperature sensors (F3, F4): ThermometerSun/ThermometerSnowflake
- Room humidity (BA): Droplets

## Test Plan
- [x] All existing tests pass
- [x] New sensor property helper tests added
- [x] PropertyRow component tests updated
- [x] TypeScript compilation successful
- [x] ESLint passes without warnings

🤖 Generated with [Claude Code](https://claude.ai/code)