### PR TITLE
improve: enhance device offline detection with logging and UI improvements

### DIFF
--- a/echonet_lite/handler/Devices.go
+++ b/echonet_lite/handler/Devices.go
@@ -254,8 +254,9 @@ func (d Devices) SetOffline(device IPAndEOJ, offline bool) {
 	key := device.Key()
 	if offline {
 		d.offlineDevices[key] = struct{}{}
+		slog.Info("デバイスをオフライン状態に設定", "device", device.Specifier())
 
-		// ベントをチャンネルに送信
+		// イベントをチャンネルに送信
 		if d.EventCh != nil {
 			select {
 			case d.EventCh <- DeviceEvent{
@@ -263,9 +264,13 @@ func (d Devices) SetOffline(device IPAndEOJ, offline bool) {
 				Type:   DeviceEventOffline,
 			}:
 				// 送信成功
+				slog.Info("デバイスオフラインイベントを送信", "device", device.Specifier())
 			default:
 				// チャンネルがブロックされている場合は無視
+				slog.Warn("デバイスオフラインイベントチャンネルがブロックされています", "device", device.Specifier())
 			}
+		} else {
+			slog.Warn("デバイスオフラインイベントチャンネルが設定されていません", "device", device.Specifier())
 		}
 	} else {
 		delete(d.offlineDevices, key)

--- a/echonet_lite/handler/ECHONETLiteHandler.go
+++ b/echonet_lite/handler/ECHONETLiteHandler.go
@@ -213,6 +213,7 @@ func NewECHONETLiteHandler(ctx context.Context, options ECHONETLieHandlerOptions
 		for ev := range core.NotificationCh {
 			if ev.Type == DeviceTimeout {
 				// デバイスをオフラインに設定
+				slog.Info("デバイスタイムアウト検出、オフライン状態に設定", "device", ev.Device.Specifier())
 				data.SetOffline(ev.Device, true)
 			}
 			wrappedCh <- ev

--- a/echonet_lite/handler/Session.go
+++ b/echonet_lite/handler/Session.go
@@ -466,9 +466,13 @@ func (s *Session) notifyDeviceTimeout(device echonet_lite.IPAndEOJ) error {
 			Error:  maxRetriesErr,
 		}:
 			// 送信成功
+			slog.Info("デバイスタイムアウト通知を送信", "device", device.Specifier())
 		default:
 			// チャンネルがブロックされている場合は無視
+			slog.Warn("タイムアウト通知チャンネルがブロックされています", "device", device.Specifier())
 		}
+	} else {
+		slog.Warn("タイムアウト通知チャンネルが設定されていません", "device", device.Specifier())
 	}
 	return maxRetriesErr
 }

--- a/server/websocket_server.go
+++ b/server/websocket_server.go
@@ -643,9 +643,7 @@ func (ws *WebSocketServer) listenForNotifications() {
 				_ = ws.broadcastMessageToClients(protocol.MessageTypeTimeoutNotification, payload)
 
 			case handler.DeviceOffline:
-				if ws.handler.IsDebug() {
-					slog.Debug("Device offline", "device", notification.Device.Specifier())
-				}
+				slog.Info("Device offline notification received", "device", notification.Device.Specifier())
 
 				// Create device offline payload
 				device := notification.Device
@@ -655,7 +653,11 @@ func (ws *WebSocketServer) listenForNotifications() {
 				}
 
 				// Broadcast the message
-				_ = ws.broadcastMessageToClients(protocol.MessageTypeDeviceOffline, payload)
+				if err := ws.broadcastMessageToClients(protocol.MessageTypeDeviceOffline, payload); err != nil {
+					slog.Error("Failed to broadcast device offline message", "error", err, "device", notification.Device.Specifier())
+				} else {
+					slog.Info("Device offline message broadcasted", "device", notification.Device.Specifier())
+				}
 			}
 		case propertyChange := <-ws.handler.PropertyChangeCh:
 			// プロパティ変化通知を処理

--- a/web/src/components/DeviceCard.test.tsx
+++ b/web/src/components/DeviceCard.test.tsx
@@ -505,4 +505,64 @@ describe('DeviceCard', () => {
       expect(updateButton).not.toBeDisabled();
     });
   });
+
+  describe('Last seen timestamp', () => {
+    it('should not show last seen in compact mode', () => {
+      render(
+        <DeviceCard
+          device={mockDevice}
+          isExpanded={false}
+          onToggleExpansion={vi.fn()}
+          onPropertyChange={mockOnPropertyChange}
+          onUpdateProperties={mockOnUpdateProperties}
+          propertyDescriptions={mockPropertyDescriptions}
+          getDeviceClassCode={mockGetDeviceClassCode}
+          devices={{ [`${mockDevice.ip} ${mockDevice.eoj}`]: mockDevice }}
+          aliases={{}}
+        />
+      );
+
+      // Should not show last seen text in compact mode
+      expect(screen.queryByText(/Last seen:/)).not.toBeInTheDocument();
+    });
+
+    it('should show last seen in expanded mode', () => {
+      render(
+        <DeviceCard
+          device={mockDevice}
+          isExpanded={true}
+          onToggleExpansion={vi.fn()}
+          onPropertyChange={mockOnPropertyChange}
+          onUpdateProperties={mockOnUpdateProperties}
+          propertyDescriptions={mockPropertyDescriptions}
+          getDeviceClassCode={mockGetDeviceClassCode}
+          devices={{ [`${mockDevice.ip} ${mockDevice.eoj}`]: mockDevice }}
+          aliases={{}}
+        />
+      );
+
+      // Should show last seen text in expanded mode
+      expect(screen.getByText(/Last seen:/)).toBeInTheDocument();
+    });
+
+    it('should show last seen with normal color in expanded mode', () => {
+      render(
+        <DeviceCard
+          device={mockDevice}
+          isExpanded={true}
+          onToggleExpansion={vi.fn()}
+          onPropertyChange={mockOnPropertyChange}
+          onUpdateProperties={mockOnUpdateProperties}
+          propertyDescriptions={mockPropertyDescriptions}
+          getDeviceClassCode={mockGetDeviceClassCode}
+          devices={{ [`${mockDevice.ip} ${mockDevice.eoj}`]: mockDevice }}
+          aliases={{}}
+        />
+      );
+
+      const lastSeenText = screen.getByText(/Last seen:/);
+      // Check for normal muted color class
+      expect(lastSeenText).toHaveClass('text-muted-foreground');
+    });
+  });
 });

--- a/web/src/components/DeviceCard.tsx
+++ b/web/src/components/DeviceCard.tsx
@@ -219,12 +219,14 @@ export function DeviceCard({
           </div>
         )}
 
-        {/* Last seen timestamp - always at bottom */}
-        <div className="border-t pt-2 pb-3 mt-2">
-          <p className="text-xs text-muted-foreground">
-            Last seen: {new Date(device.lastSeen).toLocaleString()}
-          </p>
-        </div>
+        {/* Last seen timestamp - only show in expanded mode */}
+        {isExpanded && (
+          <div className="border-t pt-2 pb-3 mt-2">
+            <p className="text-xs text-muted-foreground">
+              Last seen: {new Date(device.lastSeen).toLocaleString()}
+            </p>
+          </div>
+        )}
       </CardContent>
     </Card>
   );

--- a/web/src/hooks/useECHONET.ts
+++ b/web/src/hooks/useECHONET.ts
@@ -210,6 +210,9 @@ export function useECHONET(
         break;
 
       case 'device_offline':
+        if (import.meta.env.DEV) {
+          console.log('📤 Device going offline:', `${message.payload.ip} ${message.payload.eoj}`);
+        }
         dispatch({
           type: 'REMOVE_DEVICE',
           payload: { ip: message.payload.ip, eoj: message.payload.eoj },


### PR DESCRIPTION
## Summary
- Add comprehensive logging for device offline detection troubleshooting
- Simplify DeviceCard last seen display behavior
- Enhance Web UI debugging capabilities

## Changes Made

### Server-side Logging Improvements
- **Session timeout detection**: Added logging when device timeout notifications are sent/blocked
- **Device timeout handling**: Added logging when ECHONETLiteHandler receives timeout events
- **Offline state management**: Added logging when devices are marked offline and events are sent
- **WebSocket broadcasting**: Added logging for device_offline message transmission success/failure

### Web UI Improvements
- **DeviceCard last seen display**: Simplified to show only in expanded mode with normal styling (removed from compact mode)
- **Debug logging**: Added console logging for device_offline message reception in development mode

### Test Updates
- Updated DeviceCard tests to reflect new last seen display behavior
- All existing tests continue to pass

## Test Plan
- [x] Run Go server tests (`go test ./...`)
- [x] Run Web UI tests (`npm run test`)
- [x] Build and lint checks pass
- [x] Manual testing of offline device detection flow with new logging

## Debugging Benefits
With these logging improvements, we can now trace the complete offline detection flow:
1. Session layer timeout detection → logs timeout notification sending
2. ECHONETLiteHandler receives timeout → logs device being marked offline
3. Devices struct marks offline → logs event generation
4. WebSocket server broadcasts → logs transmission success/failure
5. Web UI receives message → logs device removal in dev mode

This will help identify where the offline detection process might be failing for devices that remain in the UI list despite being unresponsive.

🤖 Generated with [Claude Code](https://claude.ai/code)