### PR TITLE
feat: add /merged slash command for PR cleanup automation

### DIFF
--- a/.claude/commands/merged.md
+++ b/.claude/commands/merged.md
@@ -1,0 +1,35 @@
+---
+description: "Clean up after PR merge - switch to main branch and update"
+allowed-tools: ["Bash"]
+---
+
+# PR Merge Cleanup
+
+Execute the following commands to clean up after a PR has been merged.
+
+If no branch name is provided as an argument, I will use the current branch name and ask for confirmation before proceeding.
+
+Commands to execute:
+1. Switch to main branch
+2. Pull latest changes from origin
+3. Delete the merged branch (locally)
+4. Prune remote tracking branches
+
+!git status
+!echo "Current branch will be deleted after switching to main. Proceed? (y/n)"
+!read -p "Continue? " -n 1 -r
+!echo
+!if [[ $REPLY =~ ^[Yy]$ ]]; then
+!  BRANCH_TO_DELETE=${ARGUMENTS:-$(git branch --show-current)}
+!  echo "Switching to main branch..."
+!  git checkout main
+!  echo "Pulling latest changes..."
+!  git pull origin main
+!  echo "Deleting branch: $BRANCH_TO_DELETE"
+!  git branch -d $BRANCH_TO_DELETE
+!  echo "Pruning remote tracking branches..."
+!  git remote prune origin
+!  echo "Cleanup complete!"
+!else
+!  echo "Operation cancelled."
+!fi


### PR DESCRIPTION
## Summary
- Add custom slash command `/merged` for automating post-merge cleanup tasks
- Provides interactive confirmation before executing cleanup operations
- Supports branch name as argument or uses current branch as default

## Features
- Switch to main branch and pull latest changes
- Delete merged branch locally (with user confirmation)
- Prune remote tracking branches
- Interactive prompts for safety

## Usage
- `/merged` - Clean up current branch (with confirmation)
- `/merged branch-name` - Clean up specified branch

## Test plan
- [ ] Verify slash command is recognized by Claude Code
- [ ] Test with branch argument
- [ ] Test without branch argument (current branch)
- [ ] Confirm interactive prompts work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)