### PR TITLE
fix: remove duplicate CI execution by eliminating pull_request_target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,16 +5,12 @@ on:
     branches: [ main, master, develop ]
   pull_request:
     branches: [ main, master ]
-  # Run tests when Dependabot creates PRs
-  pull_request_target:
-    branches: [ main, master ]
 
 jobs:
   # Detect which files have changed to determine which tests to run
   changes:
     name: Detect Changes
     runs-on: ubuntu-latest
-    # Grant permissions for pull_request_target
     permissions:
       contents: read
       pull-requests: read
@@ -24,15 +20,11 @@ jobs:
       docs: ${{ steps.filter.outputs.docs }}
     steps:
     - uses: actions/checkout@v4
-      with:
-        # For pull_request_target, we need to checkout the PR head
-        ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
     
     - uses: dorny/paths-filter@v3
       id: filter
       with:
-        # Use the correct base for comparison
-        base: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || 'main' }}
+        base: main
         filters: |
           server:
             - '**.go'
@@ -82,9 +74,9 @@ jobs:
         path: |
           ~/.cache/go-build
           ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        key: ${{ runner.os }}-go-v2-${{ hashFiles('**/go.sum') }}
         restore-keys: |
-          ${{ runner.os }}-go-
+          ${{ runner.os }}-go-v2-
     
     - name: Download dependencies
       run: go mod download
@@ -178,9 +170,9 @@ jobs:
         path: |
           ~/.cache/go-build
           ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        key: ${{ runner.os }}-go-v2-${{ hashFiles('**/go.sum') }}
         restore-keys: |
-          ${{ runner.os }}-go-
+          ${{ runner.os }}-go-v2-
     
     - name: Set up Node.js
       uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary

- Remove `pull_request_target` trigger that was causing duplicate CI runs for the same PRs
- Simplify checkout and path filter configurations by removing conditional logic
- Update cache key to v2 to force fresh cache and avoid corruption issues

## Problem

PRs were triggering both `pull_request` and `pull_request_target` events, causing:
- Duplicate CI execution for each PR
- Unnecessary resource usage
- Potential conflicts between parallel test runs
- Blocking PR merges due to CI failures

## Solution

This fix ensures only `pull_request` triggers are used, eliminating the duplication while maintaining all necessary CI functionality.

## Testing

This PR will test the fix by ensuring only a single CI run executes for this change.

🤖 Generated with [Claude Code](https://claude.ai/code)