### PR TITLE
feat: show IP-EOJ in compact mode when device has no alias

### DIFF
--- a/web/src/components/DeviceCard.test.tsx
+++ b/web/src/components/DeviceCard.test.tsx
@@ -141,7 +141,7 @@ describe('DeviceCard', () => {
       expect(screen.queryByPlaceholderText(/alias/i)).not.toBeInTheDocument();
     });
 
-    it('should not show device IP and EOJ in compact mode', () => {
+    it('should show device IP and EOJ in compact mode when no alias exists', () => {
       render(
         <DeviceCard
           device={mockDevice}
@@ -156,9 +156,30 @@ describe('DeviceCard', () => {
         />
       );
 
-      // IP and EOJ should not be visible
-      expect(screen.queryByText(/192\.168\.1\.100/)).not.toBeInTheDocument();
-      expect(screen.queryByText(/0291:1/)).not.toBeInTheDocument();
+      // IP and EOJ should be visible when no alias exists
+      expect(screen.getByText(/192\.168\.1\.100.*0291:1/)).toBeInTheDocument();
+    });
+
+    it('should not show device IP and EOJ in compact mode when alias exists', () => {
+      // Mock to return that device has alias
+      vi.mocked(deviceIdHelper.deviceHasAlias).mockReturnValue({ hasAlias: true, aliasName: 'Living Light', deviceIdentifier: '192.168.1.100 0291:1' });
+      
+      render(
+        <DeviceCard
+          device={mockDevice}
+          isExpanded={false}
+          onToggleExpansion={vi.fn()}
+          onPropertyChange={mockOnPropertyChange}
+          onUpdateProperties={mockOnUpdateProperties}
+          propertyDescriptions={mockPropertyDescriptions}
+          getDeviceClassCode={mockGetDeviceClassCode}
+          devices={{ [`${mockDevice.ip} ${mockDevice.eoj}`]: mockDevice }}
+          aliases={{ 'Living Light': `${mockDevice.ip} ${mockDevice.eoj}` }}
+        />
+      );
+
+      // IP and EOJ should not be visible when alias exists
+      expect(screen.queryByText(/192\.168\.1\.100.*0291:1/)).not.toBeInTheDocument();
     });
   });
 

--- a/web/src/components/DeviceCard.tsx
+++ b/web/src/components/DeviceCard.tsx
@@ -80,7 +80,7 @@ export function DeviceCard({
                 Device: {device.name}
               </p>
             )}
-            {isExpanded && (
+            {(isExpanded || !aliasInfo.hasAlias) && (
               <p className="text-xs text-muted-foreground">
                 {device.ip} - {device.eoj}
               </p>


### PR DESCRIPTION
## Summary
- Modified DeviceCard to show IP-EOJ in compact mode when device has no alias
- Updated tests to verify the new display logic
- Improves device identification for non-aliased devices in compact view

## Changes
- Updated display condition from `isExpanded` to `(isExpanded || \!aliasInfo.hasAlias)`
- Split existing test into two separate test cases for better coverage
- Added test case for when alias exists (IP-EOJ should be hidden)
- Added test case for when no alias exists (IP-EOJ should be shown)

## Test plan
- [x] Verify compact mode shows IP-EOJ when device has no alias
- [x] Verify compact mode hides IP-EOJ when device has alias
- [x] Verify expanded mode always shows IP-EOJ
- [x] All existing tests pass
- [x] TypeScript compilation succeeds
- [x] Lint checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)