### PR TITLE
feat: add temperature-based color coding for sensor icons

### DIFF
--- a/web/src/components/DeviceCard.tsx
+++ b/web/src/components/DeviceCard.tsx
@@ -54,8 +54,8 @@ export function DeviceCard({
   );
 
   // For compact view, separate sensor and non-sensor properties
-  const primarySensorProps = primaryProps.filter(([epc]) => isSensorProperty(epc));
-  const primaryNonSensorProps = primaryProps.filter(([epc]) => !isSensorProperty(epc));
+  const primarySensorProps = primaryProps.filter(([epc]) => isSensorProperty(classCode, epc));
+  const primaryNonSensorProps = primaryProps.filter(([epc]) => !isSensorProperty(classCode, epc));
 
 
   return (
@@ -198,7 +198,7 @@ export function DeviceCard({
 
         </div>
 
-        {/* Sensor properties in compact mode - positioned above Last seen */}
+        {/* Sensor properties in compact mode - positioned at the bottom */}
         {!isExpanded && primarySensorProps.length > 0 && (
           <div className="border-t pt-2 mt-2">
             <div className="flex flex-wrap items-center">

--- a/web/src/components/PropertyRow.test.tsx
+++ b/web/src/components/PropertyRow.test.tsx
@@ -25,8 +25,8 @@ vi.mock('@/libs/propertyHelper', () => ({
 
 // Mock sensor property helper
 vi.mock('@/libs/sensorPropertyHelper', () => ({
-  isSensorProperty: (epc: string) => ['BB', 'BA', 'BE'].includes(epc),
-  getSensorIcon: (epc: string) => {
+  isSensorProperty: (_classCode: string, epc: string) => ['BB', 'BA', 'BE'].includes(epc),
+  getSensorIcon: (_classCode: string, epc: string) => {
     const iconMap: Record<string, any> = {
       'BB': ({ className }: { className?: string }) => 
         <svg data-testid="thermometer-icon" className={className}>Thermometer</svg>,
@@ -36,7 +36,8 @@ vi.mock('@/libs/sensorPropertyHelper', () => ({
         <svg data-testid="cloudsun-icon" className={className}>CloudSun</svg>
     };
     return iconMap[epc];
-  }
+  },
+  getSensorIconColor: (_classCode: string, _epc: string, _value: any) => 'text-muted-foreground'
 }));
 
 describe('PropertyRow', () => {

--- a/web/src/components/PropertyRow.tsx
+++ b/web/src/components/PropertyRow.tsx
@@ -1,7 +1,7 @@
 import { PropertyEditor } from './PropertyEditor';
 import { PropertyDisplay } from './PropertyDisplay';
 import { getPropertyName, getPropertyDescriptor, isPropertySettable } from '@/libs/propertyHelper';
-import { isSensorProperty, getSensorIcon } from '@/libs/sensorPropertyHelper';
+import { isSensorProperty, getSensorIcon, getSensorIconColor } from '@/libs/sensorPropertyHelper';
 import { getCurrentLocale } from '@/libs/languageHelper';
 import type { Device, PropertyValue, PropertyDescriptionData } from '@/hooks/types';
 
@@ -38,14 +38,15 @@ export function PropertyRow({
   const isSettable = hasEditCapability && isInSetPropertyMap;
 
   // Check if this is a sensor property for special compact display
-  const isSensor = isSensorProperty(epc);
-  const SensorIcon = getSensorIcon(epc);
+  const isSensor = isSensorProperty(classCode, epc);
+  const SensorIcon = getSensorIcon(classCode, epc);
+  const sensorIconColor = getSensorIconColor(classCode, epc, value);
 
   if (isCompact && isSensor && SensorIcon) {
     // Sensor properties in compact mode: icon + value only
     return (
       <div className="inline-flex items-center gap-1 text-xs mr-3 mb-1" title={propertyName}>
-        <SensorIcon className="h-3 w-3 text-muted-foreground" />
+        <SensorIcon className={`h-3 w-3 ${sensorIconColor}`} />
         <div>
           {isSettable ? (
             <PropertyEditor

--- a/web/src/libs/sensorPropertyHelper.test.ts
+++ b/web/src/libs/sensorPropertyHelper.test.ts
@@ -10,93 +10,170 @@ import {
 import {
   isSensorProperty,
   getSensorIcon,
-  getSensorEPCs
+  getSensorIconColor,
+  getSensorEPCs,
+  isTemperatureSensor
 } from './sensorPropertyHelper';
+import type { PropertyValue } from '@/hooks/types';
 
 describe('sensorPropertyHelper', () => {
   describe('isSensorProperty', () => {
-    it('should return true for room temperature EPCs', () => {
-      expect(isSensorProperty('BB')).toBe(true); // Air Conditioner
-      expect(isSensorProperty('E2')).toBe(true); // Floor Heating
+    it('should return true for valid sensor properties with classCode:EPC format', () => {
+      // Air Conditioner sensors
+      expect(isSensorProperty('0130', 'BB')).toBe(true); // Room temperature
+      expect(isSensorProperty('0130', 'BE')).toBe(true); // Outside temperature
+      expect(isSensorProperty('0130', 'BA')).toBe(true); // Room humidity
+      
+      // Floor Heating sensors
+      expect(isSensorProperty('027B', 'E2')).toBe(true); // Room temperature
+      expect(isSensorProperty('027B', 'E3')).toBe(true); // Floor temperature
+      expect(isSensorProperty('027B', 'F3')).toBe(true); // Temperature sensor 1
+      expect(isSensorProperty('027B', 'F4')).toBe(true); // Temperature sensor 2
     });
 
-    it('should return true for outside temperature EPC', () => {
-      expect(isSensorProperty('BE')).toBe(true);
+    it('should return false for non-sensor properties', () => {
+      expect(isSensorProperty('0130', '80')).toBe(false); // Power status
+      expect(isSensorProperty('0130', 'B0')).toBe(false); // Operation mode
+      expect(isSensorProperty('027B', '81')).toBe(false); // Installation location
     });
 
-    it('should return true for floor temperature EPC', () => {
-      expect(isSensorProperty('E3')).toBe(true);
+    it('should return false for wrong classCode combinations', () => {
+      // EPC BB exists for Air Conditioner but not for Floor Heating
+      expect(isSensorProperty('027B', 'BB')).toBe(false);
+      // EPC E2 exists for Floor Heating but not for Air Conditioner
+      expect(isSensorProperty('0130', 'E2')).toBe(false);
     });
 
-    it('should return true for water temperature sensor EPCs', () => {
-      expect(isSensorProperty('F3')).toBe(true); // Temperature sensor 1
-      expect(isSensorProperty('F4')).toBe(true); // Temperature sensor 2
-    });
-
-    it('should return true for humidity EPC', () => {
-      expect(isSensorProperty('BA')).toBe(true);
-    });
-
-    it('should return false for non-sensor EPCs', () => {
-      expect(isSensorProperty('80')).toBe(false); // Operation status
-      expect(isSensorProperty('B3')).toBe(false); // Temperature setting
-      expect(isSensorProperty('B4')).toBe(false); // Humidity setting
-      expect(isSensorProperty('B0')).toBe(false); // Operation mode
-      expect(isSensorProperty('XX')).toBe(false); // Unknown EPC
+    it('should return false for unknown classCode', () => {
+      expect(isSensorProperty('FFFF', 'BB')).toBe(false);
+      expect(isSensorProperty('0000', 'E2')).toBe(false);
     });
   });
 
   describe('getSensorIcon', () => {
-    it('should return Thermometer for room temperature EPCs', () => {
-      expect(getSensorIcon('BB')).toBe(Thermometer);
-      expect(getSensorIcon('E2')).toBe(Thermometer);
+    it('should return correct icons for temperature sensors', () => {
+      expect(getSensorIcon('0130', 'BB')).toBe(Thermometer);
+      expect(getSensorIcon('027B', 'E2')).toBe(Thermometer);
+      expect(getSensorIcon('0130', 'BE')).toBe(CloudSun);
+      expect(getSensorIcon('027B', 'E3')).toBe(Home);
+      expect(getSensorIcon('027B', 'F3')).toBe(ThermometerSun);
+      expect(getSensorIcon('027B', 'F4')).toBe(ThermometerSnowflake);
     });
 
-    it('should return CloudSun for outside temperature', () => {
-      expect(getSensorIcon('BE')).toBe(CloudSun);
+    it('should return correct icon for humidity sensor', () => {
+      expect(getSensorIcon('0130', 'BA')).toBe(Droplets);
     });
 
-    it('should return Home for floor temperature', () => {
-      expect(getSensorIcon('E3')).toBe(Home);
+    it('should return undefined for non-sensor properties', () => {
+      expect(getSensorIcon('0130', '80')).toBeUndefined();
+      expect(getSensorIcon('027B', '81')).toBeUndefined();
     });
 
-    it('should return ThermometerSun for temperature sensor 1', () => {
-      expect(getSensorIcon('F3')).toBe(ThermometerSun);
+    it('should return undefined for wrong classCode combinations', () => {
+      expect(getSensorIcon('027B', 'BB')).toBeUndefined();
+      expect(getSensorIcon('0130', 'E2')).toBeUndefined();
+    });
+  });
+
+  describe('isTemperatureSensor', () => {
+    it('should return true for temperature sensor properties', () => {
+      expect(isTemperatureSensor('0130', 'BB')).toBe(true);
+      expect(isTemperatureSensor('027B', 'E2')).toBe(true);
+      expect(isTemperatureSensor('0130', 'BE')).toBe(true);
+      expect(isTemperatureSensor('027B', 'E3')).toBe(true);
+      expect(isTemperatureSensor('027B', 'F3')).toBe(true);
+      expect(isTemperatureSensor('027B', 'F4')).toBe(true);
     });
 
-    it('should return ThermometerSnowflake for temperature sensor 2', () => {
-      expect(getSensorIcon('F4')).toBe(ThermometerSnowflake);
+    it('should return false for non-temperature sensors', () => {
+      expect(isTemperatureSensor('0130', 'BA')).toBe(false); // Humidity
     });
 
-    it('should return Droplets for humidity', () => {
-      expect(getSensorIcon('BA')).toBe(Droplets);
+    it('should return false for non-sensor properties', () => {
+      expect(isTemperatureSensor('0130', '80')).toBe(false);
+      expect(isTemperatureSensor('027B', '81')).toBe(false);
+    });
+  });
+
+  describe('getSensorIconColor', () => {
+    it('should return blue colors for cold temperatures', () => {
+      const coldValue: PropertyValue = { number: 5 };
+      const veryColdValue: PropertyValue = { number: -10 };
+      
+      expect(getSensorIconColor('0130', 'BB', coldValue)).toBe('text-blue-600');
+      expect(getSensorIconColor('027B', 'E2', veryColdValue)).toBe('text-blue-600');
+      
+      const coolValue: PropertyValue = { number: 12 };
+      expect(getSensorIconColor('0130', 'BB', coolValue)).toBe('text-blue-400');
     });
 
-    it('should return undefined for non-sensor EPCs', () => {
-      expect(getSensorIcon('80')).toBeUndefined();
-      expect(getSensorIcon('B3')).toBeUndefined();
-      expect(getSensorIcon('XX')).toBeUndefined();
+    it('should return red colors for hot temperatures', () => {
+      const hotValue: PropertyValue = { number: 35 };
+      const warmValue: PropertyValue = { number: 27 };
+      
+      expect(getSensorIconColor('0130', 'BB', hotValue)).toBe('text-red-600');
+      expect(getSensorIconColor('027B', 'E2', warmValue)).toBe('text-orange-400');
+    });
+
+    it('should return muted color for normal temperatures', () => {
+      const normalValue: PropertyValue = { number: 22 };
+      
+      expect(getSensorIconColor('0130', 'BB', normalValue)).toBe('text-muted-foreground');
+      expect(getSensorIconColor('027B', 'E2', normalValue)).toBe('text-muted-foreground');
+    });
+
+    it('should return muted color for non-temperature sensors', () => {
+      const humidityValue: PropertyValue = { number: 60 };
+      
+      expect(getSensorIconColor('0130', 'BA', humidityValue)).toBe('text-muted-foreground');
+    });
+
+    it('should return muted color for non-sensor properties', () => {
+      const value: PropertyValue = { number: 25 };
+      
+      expect(getSensorIconColor('0130', '80', value)).toBe('text-muted-foreground');
+      expect(getSensorIconColor('027B', '81', value)).toBe('text-muted-foreground');
+    });
+
+    it('should return muted color for non-numeric values', () => {
+      const stringValue: PropertyValue = { string: 'ON' };
+      const edtValue: PropertyValue = { EDT: 'AQ==' }; // Base64 encoded value
+      
+      expect(getSensorIconColor('0130', 'BB', stringValue)).toBe('text-muted-foreground');
+      expect(getSensorIconColor('0130', 'BB', edtValue)).toBe('text-muted-foreground');
+    });
+
+    it('should handle edge temperature values correctly', () => {
+      // Boundary testing
+      expect(getSensorIconColor('0130', 'BB', { number: 10 })).toBe('text-blue-600');
+      expect(getSensorIconColor('0130', 'BB', { number: 11 })).toBe('text-blue-400');
+      expect(getSensorIconColor('0130', 'BB', { number: 15 })).toBe('text-blue-400');
+      expect(getSensorIconColor('0130', 'BB', { number: 16 })).toBe('text-muted-foreground');
+      expect(getSensorIconColor('0130', 'BB', { number: 24 })).toBe('text-muted-foreground');
+      expect(getSensorIconColor('0130', 'BB', { number: 25 })).toBe('text-orange-400');
+      expect(getSensorIconColor('0130', 'BB', { number: 29 })).toBe('text-orange-400');
+      expect(getSensorIconColor('0130', 'BB', { number: 30 })).toBe('text-red-600');
     });
   });
 
   describe('getSensorEPCs', () => {
-    it('should return all sensor EPCs', () => {
+    it('should return all sensor EPCs with their classCode mappings', () => {
       const sensorEPCs = getSensorEPCs();
-      expect(sensorEPCs).toContain('BB');
-      expect(sensorEPCs).toContain('E2');
-      expect(sensorEPCs).toContain('BE');
-      expect(sensorEPCs).toContain('E3');
-      expect(sensorEPCs).toContain('F3');
-      expect(sensorEPCs).toContain('F4');
-      expect(sensorEPCs).toContain('BA');
-      expect(sensorEPCs).toHaveLength(7);
+      
+      expect(sensorEPCs).toContain('0130:BB');
+      expect(sensorEPCs).toContain('0130:BE');
+      expect(sensorEPCs).toContain('0130:BA');
+      expect(sensorEPCs).toContain('027B:E2');
+      expect(sensorEPCs).toContain('027B:E3');
+      expect(sensorEPCs).toContain('027B:F3');
+      expect(sensorEPCs).toContain('027B:F4');
     });
 
-    it('should not contain non-sensor EPCs', () => {
+    it('should return unique values', () => {
       const sensorEPCs = getSensorEPCs();
-      expect(sensorEPCs).not.toContain('80');
-      expect(sensorEPCs).not.toContain('B3');
-      expect(sensorEPCs).not.toContain('B4');
+      const uniqueEPCs = [...new Set(sensorEPCs)];
+      
+      expect(sensorEPCs.length).toBe(uniqueEPCs.length);
     });
   });
 });

--- a/web/src/libs/sensorPropertyHelper.ts
+++ b/web/src/libs/sensorPropertyHelper.ts
@@ -7,46 +7,90 @@ import {
   Droplets,
   type LucideIcon
 } from 'lucide-react';
+import type { PropertyValue } from '@/hooks/types';
 
-// Sensor property EPCs and their corresponding icons
+// Sensor property EPCs and their corresponding icons using classCode:EPC format
 const SENSOR_PROPERTY_ICONS: Record<string, LucideIcon> = {
-  // Room temperature (Air Conditioner & Floor Heating)
-  'BB': Thermometer,
-  'E2': Thermometer,
+  // Air Conditioner (0130) sensors
+  '0130:BB': Thermometer,  // Room temperature
+  '0130:BE': CloudSun,     // Outside temperature
+  '0130:BA': Droplets,     // Room humidity
   
-  // Outside temperature (Air Conditioner)
-  'BE': CloudSun,
-  
-  // Floor temperature (Floor Heating)
-  'E3': Home,
-  
-  // Temperature sensor 1 (Floor Heating - outgoing water temp)
-  'F3': ThermometerSun,
-  
-  // Temperature sensor 2 (Floor Heating - return water temp)
-  'F4': ThermometerSnowflake,
-  
-  // Room humidity (Air Conditioner)
-  'BA': Droplets,
+  // Floor Heating (027B) sensors
+  '027B:E2': Thermometer,        // Room temperature
+  '027B:E3': Home,               // Floor temperature
+  '027B:F3': ThermometerSun,     // Temperature sensor 1 (outgoing water temp)
+  '027B:F4': ThermometerSnowflake, // Temperature sensor 2 (return water temp)
 };
+
+// Temperature sensor EPCs (for color calculation)
+const TEMPERATURE_SENSOR_EPCS = new Set([
+  '0130:BB', '0130:BE',  // Air Conditioner temperature sensors
+  '027B:E2', '027B:E3', '027B:F3', '027B:F4'  // Floor Heating temperature sensors
+]);
+
+/**
+ * Gets the temperature color class based on the temperature value
+ * Only applies to temperature sensors, returns muted for others
+ */
+function getTemperatureColor(value: number): string {
+  if (value <= 10) return 'text-blue-600';      // Very cold
+  if (value <= 15) return 'text-blue-400';      // Cold
+  if (value <= 24) return 'text-muted-foreground'; // Normal
+  if (value <= 29) return 'text-orange-400';    // Warm
+  return 'text-red-600';                         // Hot
+}
 
 /**
  * Checks if a property EPC is a sensor property
  */
-export function isSensorProperty(epc: string): boolean {
-  return epc in SENSOR_PROPERTY_ICONS;
+export function isSensorProperty(classCode: string, epc: string): boolean {
+  const key = `${classCode}:${epc}`;
+  return key in SENSOR_PROPERTY_ICONS;
 }
 
 /**
  * Gets the icon component for a sensor property
  * Returns undefined if the property is not a sensor
  */
-export function getSensorIcon(epc: string): LucideIcon | undefined {
-  return SENSOR_PROPERTY_ICONS[epc];
+export function getSensorIcon(classCode: string, epc: string): LucideIcon | undefined {
+  const key = `${classCode}:${epc}`;
+  return SENSOR_PROPERTY_ICONS[key];
 }
 
 /**
- * Gets all sensor EPCs as an array
+ * Checks if a property is a temperature sensor
+ */
+export function isTemperatureSensor(classCode: string, epc: string): boolean {
+  const key = `${classCode}:${epc}`;
+  return TEMPERATURE_SENSOR_EPCS.has(key);
+}
+
+/**
+ * Gets the color class for a sensor icon based on its value
+ * Only temperature sensors get color-coded, others use muted color
+ */
+export function getSensorIconColor(classCode: string, epc: string, value: PropertyValue): string {
+  // Only apply color to sensor properties
+  if (!isSensorProperty(classCode, epc)) {
+    return 'text-muted-foreground';
+  }
+  
+  // Only temperature sensors get color-coded
+  if (!isTemperatureSensor(classCode, epc)) {
+    return 'text-muted-foreground';
+  }
+  
+  // Must have a numeric value
+  if (value.number === undefined) {
+    return 'text-muted-foreground';
+  }
+  
+  return getTemperatureColor(value.number);
+}
+
+/**
+ * Gets all sensor EPCs as an array with classCode:EPC format
  */
 export function getSensorEPCs(): string[] {
   return Object.keys(SENSOR_PROPERTY_ICONS);


### PR DESCRIPTION
## Summary

- 温度センサーアイコンに温度値に基づく色分け機能を追加
- SENSOR_PROPERTY_ICONSをclassCode:EPC形式に変更してEPCの誤爆を防止
- 温度センサーのみ色付け対象とし、湿度センサーは対象外

## Changes

### Color Ranges
- **Very Cold (≤10℃)**: `text-blue-600`
- **Cold (11-15℃)**: `text-blue-400`  
- **Normal (16-24℃)**: `text-muted-foreground`
- **Warm (25-29℃)**: `text-orange-400`
- **Hot (≥30℃)**: `text-red-600`

### Technical Improvements
- SENSOR_PROPERTY_ICONSのキーを`'BB'`から`'0130:BB'`形式に変更
- `getSensorIconColor()`関数を新規追加
- センサーヘルパー関数に`classCode`パラメータを追加
- 20個のテストケースで境界値・エラー処理を完全カバー

## Test Plan

- [x] Unit tests: `npm run test` - 354 tests pass
- [x] Type checking: `npm run typecheck` - No errors
- [x] Linting: `npm run lint` - No warnings
- [x] Build: `npm run build` - Success
- [x] Go tests: `go test ./...` - All pass

### Manual Testing
1. エアコン温度センサーで温度値を変更
2. 床暖房の複数温度センサーで色の変化を確認
3. 湿度センサーが色付けされないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)