### PR TITLE
Fix Claude Code Action permissions for Dependabot PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,8 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Skip Dependabot PRs (handled by separate security review workflow)
+    if: github.actor != 'dependabot[bot]'
     
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/claude-dependabot-security-review.yml
+++ b/.github/workflows/claude-dependabot-security-review.yml
@@ -1,0 +1,65 @@
+name: Claude Dependabot Security Review
+
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+
+jobs:
+  dependabot-security-review:
+    # Run only for Dependabot PRs
+    if: github.actor == 'dependabot[bot]'
+    
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 1
+
+      - name: Run Claude Security Review
+        id: claude-review
+        uses: anthropics/claude-code-action@beta
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # Optional: Use Claude Opus 4 for more thorough security analysis
+          # model: "claude-opus-4-20250514"
+          
+          # Specialized prompt for Dependabot security review
+          direct_prompt: |
+            This is a Dependabot PR for dependency updates. Please review with focus on:
+            
+            1. **Security Impact Analysis**:
+               - Check for any known vulnerabilities in the updated dependencies
+               - Assess if the version jump could introduce breaking changes
+               - Identify any new permissions or capabilities the updated packages might request
+            
+            2. **Compatibility Check**:
+               - Verify the updated versions are compatible with our existing dependencies
+               - Check if the update requires changes to our code
+               - Look for any deprecation warnings
+            
+            3. **Risk Assessment**:
+               - Evaluate the size and scope of the changes
+               - Check the release notes for any security advisories
+               - Assess the stability of the new versions (stable vs beta/alpha)
+            
+            4. **Recommendations**:
+               - Provide a clear recommendation: Safe to merge / Needs manual testing / Do not merge
+               - If manual testing is needed, specify what should be tested
+               - Suggest any additional security measures if needed
+            
+            Be concise and focus on actionable security insights.
+
+          # Optional: Use sticky comments for consistent feedback across updates
+          use_sticky_comment: true
+          
+          # Optional: Add tools for checking package details
+          # allowed_tools: "Bash(npm audit),Bash(npm ls),Bash(go mod graph)"


### PR DESCRIPTION
## Summary
- Fix Claude Code Action write permission errors on Dependabot PRs
- Split workflows for better security and functionality separation

## Changes
- **Regular PR workflow** (`claude-code-review.yml`): Continue handling user PRs with `pull_request` trigger
- **Dependabot security workflow** (`claude-dependabot-security-review.yml`): New workflow for dependency updates using `pull_request_target` trigger
- Dependabot-specific security review prompts focused on vulnerability analysis and compatibility checking

## Test plan
- [ ] Verify regular PRs still trigger Claude Code review as expected
- [ ] Test Dependabot PR triggers the new security review workflow
- [ ] Confirm no permission errors occur for either workflow type

## Background
Dependabot PRs have restricted GitHub token permissions since 2021, causing write access failures for Claude Code Action. This fix uses `pull_request_target` for Dependabot PRs to restore write permissions while maintaining security through actor restrictions.

🤖 Generated with [Claude Code](https://claude.ai/code)