### PR TITLE
fix: suppress broken pipe errors in WebSocket broadcast operations

### DIFF
--- a/server/websocket_server.go
+++ b/server/websocket_server.go
@@ -654,7 +654,9 @@ func (ws *WebSocketServer) listenForNotifications() {
 
 				// Broadcast the message
 				if err := ws.broadcastMessageToClients(protocol.MessageTypeDeviceOffline, payload); err != nil {
-					slog.Error("Failed to broadcast device offline message", "error", err, "device", notification.Device.Specifier())
+					if !isClientDisconnectedError(err) {
+						slog.Error("Failed to broadcast device offline message", "error", err, "device", notification.Device.Specifier())
+					}
 				} else {
 					slog.Info("Device offline message broadcasted", "device", notification.Device.Specifier())
 				}
@@ -676,7 +678,9 @@ func (ws *WebSocketServer) listenForNotifications() {
 			// メッセージを非同期でブロードキャスト
 			go func() {
 				if err := ws.broadcastMessageToClients(protocol.MessageTypePropertyChanged, payload); err != nil {
-					slog.Error("Failed to broadcast property change", "error", err, "device", propertyChange.Device.Specifier())
+					if !isClientDisconnectedError(err) {
+						slog.Error("Failed to broadcast property change", "error", err, "device", propertyChange.Device.Specifier())
+					}
 				}
 			}()
 		}


### PR DESCRIPTION
## Summary

- Suppress broken pipe and client disconnection errors in WebSocket broadcast operations
- These errors are normal occurrences when clients disconnect and don't require error logging
- Maintains error reporting for genuine broadcast failures

## Changes

- **Device offline broadcast**: Added `isClientDisconnectedError()` check before logging errors
- **Property change broadcast**: Added `isClientDisconnectedError()` check before logging errors

## Technical Details

The existing `isClientDisconnectedError()` function already properly identifies:
- Broken pipe errors
- Connection reset by peer
- Use of closed network connection
- Other client disconnection patterns

These checks are now applied to both broadcast operations to reduce log noise while preserving error reporting for actual broadcast failures.

## Test Plan

- [x] Go format, vet, test, and build passed
- [x] Web UI lint, typecheck, test, and build passed
- [x] Verified `isClientDisconnectedError()` function correctly identifies broken pipe errors
- [x] Confirmed broadcast operations continue to work normally
- [x] Error logging is suppressed for client disconnection scenarios
- [x] Error logging is preserved for genuine broadcast failures

🤖 Generated with [Claude Code](https://claude.ai/code)