### PR TITLE
refactor: extract device deletion dialog with i18n support

### DIFF
--- a/web/src/components/DeviceCard.tsx
+++ b/web/src/components/DeviceCard.tsx
@@ -1,20 +1,11 @@
 import { ChevronDown, ChevronUp, RefreshCw, Trash2 } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from '@/components/ui/alert-dialog';
 import { PropertyRow } from '@/components/PropertyRow';
 import { AliasEditor } from '@/components/AliasEditor';
 import { DeviceStatusIndicators } from '@/components/DeviceStatusIndicators';
+import { DeviceDeleteConfirmDialog } from '@/components/DeviceDeleteConfirmDialog';
+import { useState } from 'react';
 import { isPropertyPrimary, getSortedPrimaryProperties } from '@/libs/deviceTypeHelper';
 import { deviceHasAlias, getDeviceIdentifierForAlias, getDeviceAliases } from '@/libs/deviceIdHelper';
 import { isSensorProperty } from '@/libs/sensorPropertyHelper';
@@ -57,6 +48,7 @@ export function DeviceCard({
   onDeleteDevice,
   isDeletingDevice = false
 }: DeviceCardProps) {
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const aliasInfo = deviceHasAlias(device, devices, aliases);
   const deviceAliasesInfo = getDeviceAliases(device, devices, aliases);
   const classCode = getDeviceClassCode(device);
@@ -119,44 +111,28 @@ export function DeviceCard({
               </Button>
             )}
             {device.isOffline && onDeleteDevice && (
-              <AlertDialog>
-                <AlertDialogTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="h-6 w-6 p-0 text-destructive hover:text-destructive"
-                    title="Delete offline device"
-                    disabled={isDeletingDevice || !isConnected}
-                    data-testid="delete-device-button"
-                  >
-                    <Trash2 className="h-3 w-3" />
-                  </Button>
-                </AlertDialogTrigger>
-                <AlertDialogContent>
-                  <AlertDialogHeader>
-                    <AlertDialogTitle>Delete Offline Device</AlertDialogTitle>
-                    <AlertDialogDescription>
-                      Are you sure you want to delete &quot;{aliasInfo.aliasName || device.name}&quot;?
-                      <br />
-                      <span className="text-xs text-muted-foreground mt-1 block">
-                        {device.ip} - {device.eoj}
-                      </span>
-                      <br />
-                      This action cannot be undone. The device will be permanently removed from the device list.
-                    </AlertDialogDescription>
-                  </AlertDialogHeader>
-                  <AlertDialogFooter>
-                    <AlertDialogCancel>Cancel</AlertDialogCancel>
-                    <AlertDialogAction
-                      className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-                      onClick={() => onDeleteDevice(`${device.ip} ${device.eoj}`)}
-                      disabled={isDeletingDevice}
-                    >
-                      {isDeletingDevice ? "Deleting..." : "Delete Device"}
-                    </AlertDialogAction>
-                  </AlertDialogFooter>
-                </AlertDialogContent>
-              </AlertDialog>
+              <>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-6 w-6 p-0 text-destructive hover:text-destructive"
+                  title="Delete offline device"
+                  disabled={isDeletingDevice || !isConnected}
+                  data-testid="delete-device-button"
+                  onClick={() => setIsDeleteDialogOpen(true)}
+                >
+                  <Trash2 className="h-3 w-3" />
+                </Button>
+                <DeviceDeleteConfirmDialog
+                  device={device}
+                  aliasName={aliasInfo.aliasName}
+                  onDeleteDevice={onDeleteDevice}
+                  isDeletingDevice={isDeletingDevice}
+                  isConnected={isConnected}
+                  isOpen={isDeleteDialogOpen}
+                  onOpenChange={setIsDeleteDialogOpen}
+                />
+              </>
             )}
             <Button
               variant="ghost"

--- a/web/src/components/DeviceDeleteConfirmDialog.test.tsx
+++ b/web/src/components/DeviceDeleteConfirmDialog.test.tsx
@@ -1,0 +1,249 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { DeviceDeleteConfirmDialog } from './DeviceDeleteConfirmDialog';
+import type { Device } from '@/hooks/types';
+
+// Mock the language helper
+vi.mock('@/libs/languageHelper', () => ({
+  isJapanese: vi.fn(),
+}));
+
+const { isJapanese } = vi.mocked(await import('@/libs/languageHelper'));
+
+describe('DeviceDeleteConfirmDialog', () => {
+  const mockDevice: Device = {
+    ip: '192.168.1.100',
+    eoj: '013001',
+    name: 'Air Conditioner',
+    id: '013001:0000:001234',
+    properties: {},
+    lastSeen: '2024-01-01T12:00:00Z',
+    isOffline: true,
+  };
+
+  const defaultProps = {
+    device: mockDevice,
+    onDeleteDevice: vi.fn(),
+    isDeletingDevice: false,
+    isConnected: true,
+    isOpen: true,
+    onOpenChange: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    isJapanese.mockReturnValue(false); // Default to English
+  });
+
+  describe('English Language', () => {
+    beforeEach(() => {
+      isJapanese.mockReturnValue(false);
+    });
+
+    it('should render English texts when language is not Japanese', () => {
+      render(<DeviceDeleteConfirmDialog {...defaultProps} />);
+
+      expect(screen.getByText('Delete Offline Device')).toBeInTheDocument();
+      expect(screen.getByText(/Are you sure you want to delete "Air Conditioner"\?/)).toBeInTheDocument();
+      expect(screen.getByText(/This action cannot be undone/)).toBeInTheDocument();
+      expect(screen.getByText('Cancel')).toBeInTheDocument();
+      expect(screen.getByText('Delete Device')).toBeInTheDocument();
+    });
+
+    it('should display device IP and EOJ in English', () => {
+      render(<DeviceDeleteConfirmDialog {...defaultProps} />);
+
+      expect(screen.getByText('192.168.1.100 - 013001')).toBeInTheDocument();
+    });
+
+    it('should use alias name in English description when provided', () => {
+      render(
+        <DeviceDeleteConfirmDialog 
+          {...defaultProps} 
+          aliasName="Living Room AC"
+        />
+      );
+
+      expect(screen.getByText(/Are you sure you want to delete "Living Room AC"\?/)).toBeInTheDocument();
+    });
+
+    it('should show deleting state in English', () => {
+      render(
+        <DeviceDeleteConfirmDialog 
+          {...defaultProps} 
+          isDeletingDevice={true}
+        />
+      );
+
+      expect(screen.getByText('Deleting...')).toBeInTheDocument();
+    });
+  });
+
+  describe('Japanese Language', () => {
+    beforeEach(() => {
+      isJapanese.mockReturnValue(true);
+    });
+
+    it('should render Japanese texts when language is Japanese', () => {
+      render(<DeviceDeleteConfirmDialog {...defaultProps} />);
+
+      expect(screen.getByText('オフラインデバイスを削除')).toBeInTheDocument();
+      expect(screen.getByText(/「Air Conditioner」を削除してもよろしいですか？/)).toBeInTheDocument();
+      expect(screen.getByText(/この操作は取り消すことができません/)).toBeInTheDocument();
+      expect(screen.getByText('キャンセル')).toBeInTheDocument();
+      expect(screen.getByText('デバイスを削除')).toBeInTheDocument();
+    });
+
+    it('should display device IP and EOJ in Japanese (same format)', () => {
+      render(<DeviceDeleteConfirmDialog {...defaultProps} />);
+
+      expect(screen.getByText('192.168.1.100 - 013001')).toBeInTheDocument();
+    });
+
+    it('should use alias name in Japanese description when provided', () => {
+      render(
+        <DeviceDeleteConfirmDialog 
+          {...defaultProps} 
+          aliasName="リビングエアコン"
+        />
+      );
+
+      expect(screen.getByText(/「リビングエアコン」を削除してもよろしいですか？/)).toBeInTheDocument();
+    });
+
+    it('should show deleting state in Japanese', () => {
+      render(
+        <DeviceDeleteConfirmDialog 
+          {...defaultProps} 
+          isDeletingDevice={true}
+        />
+      );
+
+      expect(screen.getByText('削除中...')).toBeInTheDocument();
+    });
+  });
+
+  describe('Functionality', () => {
+    it('should call onDeleteDevice with correct target when delete button is clicked', async () => {
+      const mockOnDeleteDevice = vi.fn();
+      render(
+        <DeviceDeleteConfirmDialog 
+          {...defaultProps} 
+          onDeleteDevice={mockOnDeleteDevice}
+        />
+      );
+
+      const deleteButton = screen.getByText('Delete Device');
+      fireEvent.click(deleteButton);
+
+      await waitFor(() => {
+        expect(mockOnDeleteDevice).toHaveBeenCalledWith('192.168.1.100 013001');
+      });
+    });
+
+    it('should call onOpenChange when cancel button is clicked', async () => {
+      const mockOnOpenChange = vi.fn();
+      render(
+        <DeviceDeleteConfirmDialog 
+          {...defaultProps} 
+          onOpenChange={mockOnOpenChange}
+        />
+      );
+
+      const cancelButton = screen.getByText('Cancel');
+      fireEvent.click(cancelButton);
+
+      await waitFor(() => {
+        expect(mockOnOpenChange).toHaveBeenCalledWith(false);
+      });
+    });
+
+    it('should disable delete button when isDeletingDevice is true', () => {
+      render(
+        <DeviceDeleteConfirmDialog 
+          {...defaultProps} 
+          isDeletingDevice={true}
+        />
+      );
+
+      const deleteButton = screen.getByText('Deleting...');
+      expect(deleteButton).toBeDisabled();
+    });
+
+    it('should disable delete button when isConnected is false', () => {
+      render(
+        <DeviceDeleteConfirmDialog 
+          {...defaultProps} 
+          isConnected={false}
+        />
+      );
+
+      const deleteButton = screen.getByText('Delete Device');
+      expect(deleteButton).toBeDisabled();
+    });
+
+    it('should disable cancel button when isDeletingDevice is true', () => {
+      render(
+        <DeviceDeleteConfirmDialog 
+          {...defaultProps} 
+          isDeletingDevice={true}
+        />
+      );
+
+      const cancelButton = screen.getByText('Cancel');
+      expect(cancelButton).toBeDisabled();
+    });
+
+    it('should not render when isOpen is false', () => {
+      render(
+        <DeviceDeleteConfirmDialog 
+          {...defaultProps} 
+          isOpen={false}
+        />
+      );
+
+      expect(screen.queryByText('Delete Offline Device')).not.toBeInTheDocument();
+      expect(screen.queryByText('オフラインデバイスを削除')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Props Handling', () => {
+    it('should handle missing aliasName gracefully', () => {
+      render(<DeviceDeleteConfirmDialog {...defaultProps} />);
+
+      expect(screen.getByText(/Are you sure you want to delete "Air Conditioner"\?/)).toBeInTheDocument();
+    });
+
+    it('should prefer aliasName over device.name when both are provided', () => {
+      render(
+        <DeviceDeleteConfirmDialog 
+          {...defaultProps} 
+          aliasName="My Custom Name"
+        />
+      );
+
+      expect(screen.getByText(/Are you sure you want to delete "My Custom Name"\?/)).toBeInTheDocument();
+      expect(screen.queryByText(/Are you sure you want to delete "Air Conditioner"\?/)).not.toBeInTheDocument();
+    });
+
+    it('should construct correct device target string', () => {
+      const mockOnDeleteDevice = vi.fn();
+      render(
+        <DeviceDeleteConfirmDialog 
+          {...defaultProps} 
+          device={{
+            ...mockDevice,
+            ip: '10.0.0.50',
+            eoj: '026001',
+          }}
+          onDeleteDevice={mockOnDeleteDevice}
+        />
+      );
+
+      const deleteButton = screen.getByText('Delete Device');
+      fireEvent.click(deleteButton);
+
+      expect(mockOnDeleteDevice).toHaveBeenCalledWith('10.0.0.50 026001');
+    });
+  });
+});

--- a/web/src/components/DeviceDeleteConfirmDialog.tsx
+++ b/web/src/components/DeviceDeleteConfirmDialog.tsx
@@ -1,0 +1,96 @@
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { isJapanese } from '@/libs/languageHelper';
+import type { Device } from '@/hooks/types';
+
+type DialogMessages = {
+  title: string;
+  description: string;
+  warning: string;
+  cancel: string;
+  delete: string;
+  deleting: string;
+};
+
+interface DeviceDeleteConfirmDialogProps {
+  device: Device;
+  aliasName?: string;
+  onDeleteDevice: (target: string) => Promise<void>;
+  isDeletingDevice: boolean;
+  isConnected: boolean;
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function DeviceDeleteConfirmDialog({
+  device,
+  aliasName,
+  onDeleteDevice,
+  isDeletingDevice,
+  isConnected,
+  isOpen,
+  onOpenChange,
+}: DeviceDeleteConfirmDialogProps) {
+  const deviceDisplayName = aliasName || device.name;
+  const deviceTarget = `${device.ip} ${device.eoj}`;
+
+  const messages: Record<'en' | 'ja', DialogMessages> = {
+    en: {
+      title: 'Delete Offline Device',
+      description: `Are you sure you want to delete "${deviceDisplayName}"?`,
+      warning: 'This action cannot be undone. The device will be permanently removed from the device list.',
+      cancel: 'Cancel',
+      delete: 'Delete Device',
+      deleting: 'Deleting...',
+    },
+    ja: {
+      title: 'オフラインデバイスを削除',
+      description: `「${deviceDisplayName}」を削除してもよろしいですか？`,
+      warning: 'この操作は取り消すことができません。デバイスはデバイスリストから完全に削除されます。',
+      cancel: 'キャンセル',
+      delete: 'デバイスを削除',
+      deleting: '削除中...',
+    },
+  };
+
+  const texts = isJapanese() ? messages.ja : messages.en;
+
+  return (
+    <AlertDialog open={isOpen} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{texts.title}</AlertDialogTitle>
+          <AlertDialogDescription>
+            {texts.description}
+            <br />
+            <span className="text-xs text-muted-foreground mt-1 block">
+              {device.ip} - {device.eoj}
+            </span>
+            <br />
+            {texts.warning}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isDeletingDevice}>
+            {texts.cancel}
+          </AlertDialogCancel>
+          <AlertDialogAction
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            onClick={() => onDeleteDevice(deviceTarget)}
+            disabled={isDeletingDevice || !isConnected}
+          >
+            {isDeletingDevice ? texts.deleting : texts.delete}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}


### PR DESCRIPTION
## Summary

- Extract device deletion confirmation AlertDialog from DeviceCard into a reusable component
- Add comprehensive Japanese language support using existing languageHelper
- Implement type-safe message definitions to prevent translation inconsistencies

## Changes

### 🔄 **Component Extraction**
- **New**: `DeviceDeleteConfirmDialog.tsx` - Reusable deletion confirmation dialog
- **Modified**: `DeviceCard.tsx` - Uses new dialog component instead of inline AlertDialog

### 🌐 **Internationalization**
- Language-separated message definitions (English/Japanese)
- Type-safe `DialogMessages` interface prevents missing translations
- All UI text properly localized:
  - Dialog title and descriptions
  - Button labels (Cancel/Delete)
  - Loading states

### 🧪 **Test Coverage**
- **New**: `DeviceDeleteConfirmDialog.test.tsx` - 17 comprehensive tests
- Tests cover both English and Japanese language scenarios
- Validates all interactive states and prop handling
- All existing tests continue to pass (392 total)

## Technical Details

### Type Safety
```typescript
type DialogMessages = {
  title: string;
  description: string;
  warning: string;
  cancel: string;
  delete: string;
  deleting: string;
};

const messages: Record<'en' | 'ja', DialogMessages> = {
  // Ensures all properties are defined for each language
};
```

### Language Structure
- Clean separation between English and Japanese message sets
- Easy to extend for additional languages in the future
- Leverages existing `languageHelper.isJapanese()` function

## Test Plan

- ✅ TypeScript compilation passes
- ✅ ESLint checks pass  
- ✅ All 392 tests pass including new dialog tests
- ✅ Production build successful
- ✅ Go backend tests and build pass

🤖 Generated with [Claude Code](https://claude.ai/code)