### PR TITLE
feat: include offline devices in initial_state with isOffline field

### DIFF
--- a/docs/websocket_client_protocol.md
+++ b/docs/websocket_client_protocol.md
@@ -77,7 +77,8 @@ wss://hostname:port/ws     // SSL/TLS暗号化接続
     "80": { "EDT": "MzA=", "string": "on" },  // EPC "80" (OperationStatus)
     "B3": { "EDT": "MjU=", "string": "25", "number": 25 }   // EPC "B3" (温度設定)
   },
-  "lastSeen": "2023-04-01T12:34:56Z"
+  "lastSeen": "2023-04-01T12:34:56Z",
+  "isOffline": false // オプション：デバイスがオフライン状態の場合のみ true が設定される
 }
 ```
 
@@ -98,6 +99,10 @@ wss://hostname:port/ws     // SSL/TLS暗号化接続
     - `string`: 人間が読める文字列表現（必須ではない）
     - `number`: 数値表現（PropertyDescにNumberDescが含まれる場合のみ使用可能、必須ではない）
 - `lastSeen`: デバイスのプロパティが最後に更新された時刻（ISO 8601形式）
+- `isOffline`: デバイスのオフライン状態（オプション、`omitempty`）
+  - `true`: デバイスがオフライン状態（通信不可）
+  - `false` または未設定: デバイスがオンライン状態
+  - `initial_state` メッセージでオフラインデバイスも含めて送信される
 
 #### Error（エラー情報）
 
@@ -172,6 +177,17 @@ wss://hostname:port/ws     // SSL/TLS暗号化接続
           "B3": { "EDT": "NTA=", "string": "50", "number": 50 }
         },
         "lastSeen": "2023-04-01T12:35:00Z"
+      },
+      "192.168.1.12 0130:2": {
+        "ip": "192.168.1.12",
+        "eoj": "0130:2",
+        "name": "HomeAirConditioner",
+        "properties": {
+          "80": { "EDT": "MzE=", "string": "off" },
+          "B3": { "EDT": "MjI=", "string": "22", "number": 22 }
+        },
+        "lastSeen": "2023-04-01T12:30:00Z",
+        "isOffline": true // オフラインデバイスも initial_state に含まれる
       }
     },
     "aliases": {
@@ -275,7 +291,9 @@ wss://hostname:port/ws     // SSL/TLS暗号化接続
 
 ### device_offline
 
-デバイスがオフラインとしてマークされたことを通知します。クライアントはこのデバイスを管理リストから削除するべきです。
+デバイスがオフラインとしてマークされたことを通知します。クライアントはこのデバイスにオフライン状態のマーキング（`isOffline: true`）を適用するべきです。
+
+**注意**: このメッセージは既に接続済みのクライアントにのみ送信されます。新規接続クライアントは `initial_state` でオフラインデバイスを `isOffline: true` フィールド付きで受信します。
 
 ```json
 {

--- a/echonet_lite/handler/ECHONETLiteHandler.go
+++ b/echonet_lite/handler/ECHONETLiteHandler.go
@@ -437,3 +437,8 @@ func (h *ECHONETLiteHandler) AvailablePropertyAliases(classCode EOJClassCode) ma
 func (h *ECHONETLiteHandler) RemoveDevice(device IPAndEOJ) error {
 	return h.data.RemoveDevice(device)
 }
+
+// IsOffline は、指定されたデバイスがオフラインかどうかを返す
+func (h *ECHONETLiteHandler) IsOffline(device IPAndEOJ) bool {
+	return h.data.IsOffline(device)
+}

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -99,6 +99,7 @@ type Device struct {
 	ID         handler.IDString        `json:"id,omitempty"`
 	Properties map[string]PropertyData `json:"properties"`
 	LastSeen   time.Time               `json:"lastSeen"`
+	IsOffline  bool                    `json:"isOffline,omitempty"`
 }
 
 // Error represents an error in the WebSocket protocol
@@ -315,7 +316,7 @@ func (props PropertyMap) Set(epc echonet_lite.EPCType, data PropertyData) {
 }
 
 // DeviceToProtocol converts an ECHONET Lite device to a protocol Device
-func DeviceToProtocol(ipAndEOJ echonet_lite.IPAndEOJ, properties echonet_lite.Properties, lastSeen time.Time) Device {
+func DeviceToProtocol(ipAndEOJ echonet_lite.IPAndEOJ, properties echonet_lite.Properties, lastSeen time.Time, isOffline bool) Device {
 	protoProps := make(PropertyMap)
 	for _, prop := range properties {
 		protoProps.Set(prop.EPC, MakePropertyData(ipAndEOJ.EOJ.ClassCode(), prop))
@@ -334,6 +335,7 @@ func DeviceToProtocol(ipAndEOJ echonet_lite.IPAndEOJ, properties echonet_lite.Pr
 		ID:         ids,
 		Properties: protoProps,
 		LastSeen:   lastSeen,
+		IsOffline:  isOffline,
 	}
 }
 

--- a/protocol/protocol_test.go
+++ b/protocol/protocol_test.go
@@ -62,7 +62,7 @@ func TestDeviceToProtocol(t *testing.T) {
 	// Run tests
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := DeviceToProtocol(tt.ipAndEOJ, tt.properties, tt.lastSeen)
+			got := DeviceToProtocol(tt.ipAndEOJ, tt.properties, tt.lastSeen, false)
 
 			// Check IP
 			if got.IP != tt.want.IP {
@@ -255,7 +255,7 @@ func TestDeviceRoundTrip(t *testing.T) {
 	lastSeen := time.Now()
 
 	// Convert to protocol Device
-	protoDevice := DeviceToProtocol(ipAndEOJ, properties, lastSeen)
+	protoDevice := DeviceToProtocol(ipAndEOJ, properties, lastSeen, false)
 
 	// Convert back to ECHONET Lite types
 	gotIPAndEOJ, gotProps, err := DeviceFromProtocol(protoDevice)

--- a/server/websocket_server_handlers_devices.go
+++ b/server/websocket_server_handlers_devices.go
@@ -73,10 +73,16 @@ func (ws *WebSocketServer) handleListDevicesFromClient(msg *protocol.Message) pr
 		lastSeen := ws.handler.GetLastUpdateTime(device.Device)
 
 		// Use DeviceToProtocol to convert to protocol format
+		// Check if device is offline
+		var isOffline bool
+		if ws.handler != nil {
+			isOffline = ws.handler.IsOffline(device.Device)
+		}
 		protoDevice := protocol.DeviceToProtocol(
 			device.Device,
 			device.Properties,
 			lastSeen,
+			isOffline,
 		)
 		results = append(results, protoDevice)
 	}

--- a/server/websocket_server_handlers_properties.go
+++ b/server/websocket_server_handlers_properties.go
@@ -76,10 +76,16 @@ func (ws *WebSocketServer) handleGetPropertiesFromClient(msg *protocol.Message) 
 		lastSeen := ws.handler.GetLastUpdateTime(deviceAndProps.Device)
 
 		// Use DeviceToProtocol to convert to protocol format
+		// Check if device is offline
+		var isOffline bool
+		if ws.handler != nil {
+			isOffline = ws.handler.IsOffline(deviceAndProps.Device)
+		}
 		protoDevice := protocol.DeviceToProtocol(
 			deviceAndProps.Device,
 			deviceAndProps.Properties,
 			lastSeen,
+			isOffline,
 		)
 		results = append(results, protoDevice)
 	}
@@ -263,10 +269,16 @@ func (ws *WebSocketServer) handleSetPropertiesFromClient(msg *protocol.Message) 
 	lastSeen := ws.handler.GetLastUpdateTime(deviceAndProps.Device)
 
 	// Use DeviceToProtocol to convert to protocol format
+	// Check if device is offline
+	var isOffline bool
+	if ws.handler != nil {
+		isOffline = ws.handler.IsOffline(deviceAndProps.Device)
+	}
 	deviceData := protocol.DeviceToProtocol(
 		deviceAndProps.Device,
 		deviceAndProps.Properties,
 		lastSeen,
+		isOffline,
 	)
 
 	// Marshal the device data


### PR DESCRIPTION
## Summary

This PR adds offline device support to the `initial_state` WebSocket message, ensuring that all clients (including new connections) can see offline devices with proper status indicators.

## Key Changes

- **Added `isOffline` field** to `protocol.Device` struct with `omitempty` JSON tag
- **Updated `DeviceToProtocol` function** to accept and properly set offline status parameter  
- **Modified initial_state handler** to include offline devices by setting `ExcludeOffline: false`
- **Added `IsOffline` method** to `ECHONETLiteHandler` to expose offline status checking
- **Updated all `DeviceToProtocol` calls** throughout the codebase with proper offline status checking
- **Added nil checks** in WebSocket handlers to prevent panics in test environments

## Technical Details

### Backend Changes
- `protocol/protocol.go`: Added `IsOffline bool` field to Device struct
- `echonet_lite/handler/ECHONETLiteHandler.go`: Added delegation method for offline checking
- `server/websocket_server.go`: Modified device list fetching to include offline devices
- All WebSocket handlers now check device offline status and pass it to `DeviceToProtocol`

### Frontend Compatibility
- Web UI already supports the `isOffline` field in the Device type
- Offline devices will be displayed with appropriate visual indicators
- No changes required to existing offline device handling logic

## Benefits

1. **Consistent offline device visibility** - New clients see the same offline devices as existing clients
2. **Improved user experience** - Users don't lose track of devices that went offline before connecting
3. **Better state synchronization** - All clients have the same view of device states
4. **Backward compatibility** - `omitempty` tag ensures no breaking changes for existing clients

## Test Results

- ✅ **Go**: All tests pass (`go test ./...`, `go build`)
- ✅ **Web UI**: All checks pass (`npm run lint`, `npm run typecheck`, `npm run test`, `npm run build`)
- ✅ **Integration**: Nil safety checks added for test environments

## Breaking Changes

None - the `isOffline` field uses `omitempty` tag and Web UI already supports this field.

🤖 Generated with [Claude Code](https://claude.ai/code)