### PR TITLE
fix: suppress broken pipe errors in WebSocket broadcast

### DIFF
--- a/server/transport.go
+++ b/server/transport.go
@@ -220,9 +220,9 @@ func (t *DefaultWebSocketTransport) BroadcastMessage(message []byte) error {
 	for connID, client := range clients {
 		client.mutex.Lock()
 		if err := client.conn.WriteMessage(websocket.TextMessage, message); err != nil {
-			// Check if this is a connection close error
+			// Check if this is a client disconnection error (reuses the logic from websocket_server.go)
 			if websocket.IsCloseError(err, websocket.CloseGoingAway, websocket.CloseAbnormalClosure, websocket.CloseNoStatusReceived) ||
-				strings.Contains(err.Error(), "close sent") || strings.Contains(err.Error(), "use of closed network connection") {
+				strings.Contains(err.Error(), "close sent") || isClientDisconnectedError(err) {
 				disconnectedClients = append(disconnectedClients, connID)
 			} else {
 				slog.Error("Error broadcasting message to client", "err", err, "connID", connID)


### PR DESCRIPTION
## Summary

- Fix broken pipe error logging in WebSocket message broadcasting
- Reuse existing `isClientDisconnectedError` function for consistent error handling
- Prevent logging normal client disconnections as errors

## Changes

- Updated `transport.go` to use `isClientDisconnectedError` function from `websocket_server.go`
- Maintains proper client cleanup while reducing log noise
- No functional changes to connection handling logic

## Test Results

✅ **Go precheck passed:**
- `go fmt ./...` - no formatting changes needed
- `go vet ./...` - no issues detected  
- `go test ./...` - all tests passed
- `go build` - successful build

✅ **Web UI precheck passed:**
- `npm run lint` - no linting errors
- `npm run typecheck` - type checking passed
- `npm run test` - all 395 tests passed
- `npm run build` - successful build

🤖 Generated with [Claude Code](https://claude.ai/code)