### PR TITLE
feat: add jitter to UDP retransmissions to prevent network congestion

### DIFF
--- a/echonet_lite/handler/Session_jitter_test.go
+++ b/echonet_lite/handler/Session_jitter_test.go
@@ -1,6 +1,8 @@
 package handler
 
 import (
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 )
@@ -16,11 +18,11 @@ func TestSession_calculateRetryIntervalWithJitter(t *testing.T) {
 		intervals[i] = session.calculateRetryIntervalWithJitter()
 	}
 
-	// 基準値の範囲を確認（±30%のジッタ）
+	// 基準値の範囲を確認（定数を使用）
 	baseInterval := session.RetryInterval
-	minExpected := time.Duration(float64(baseInterval) * 0.7) // -30%
-	maxExpected := time.Duration(float64(baseInterval) * 1.3) // +30%
-	minAllowed := baseInterval / 2                            // 最小値は基準値の50%
+	minExpected := time.Duration(float64(baseInterval) * (1.0 - JitterPercentage)) // -30%
+	maxExpected := time.Duration(float64(baseInterval) * (1.0 + JitterPercentage)) // +30%
+	minAllowed := time.Duration(float64(baseInterval) * MinIntervalRatio)          // 最小値は基準値の50%
 
 	// すべての値が期待される範囲内にあることを確認
 	for i, interval := range intervals {
@@ -65,9 +67,160 @@ func TestSession_calculateRetryIntervalWithJitter_MinimumValue(t *testing.T) {
 	// 最小値の保証を確認
 	for i := 0; i < 100; i++ {
 		interval := session.calculateRetryIntervalWithJitter()
-		minAllowed := session.RetryInterval / 2
+		minAllowed := time.Duration(float64(session.RetryInterval) * MinIntervalRatio)
 		if interval < minAllowed {
 			t.Errorf("Interval (%v) is less than minimum allowed (%v)", interval, minAllowed)
 		}
+	}
+}
+
+// TestSession_calculateRetryIntervalWithJitter_InvalidInput は無効な入力値に対するテスト
+func TestSession_calculateRetryIntervalWithJitter_InvalidInput(t *testing.T) {
+	tests := []struct {
+		name          string
+		retryInterval time.Duration
+		expectDefault bool
+	}{
+		{
+			name:          "Zero interval",
+			retryInterval: 0,
+			expectDefault: true,
+		},
+		{
+			name:          "Negative interval",
+			retryInterval: -1 * time.Second,
+			expectDefault: true,
+		},
+		{
+			name:          "Valid interval",
+			retryInterval: 2 * time.Second,
+			expectDefault: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			session := &Session{
+				RetryInterval: tt.retryInterval,
+			}
+
+			interval := session.calculateRetryIntervalWithJitter()
+
+			if tt.expectDefault {
+				// デフォルト値（3秒）が返されることを確認
+				if interval != 3*time.Second {
+					t.Errorf("Expected default interval 3s, got %v", interval)
+				}
+			} else {
+				// 有効な範囲内の値が返されることを確認
+				minAllowed := time.Duration(float64(tt.retryInterval) * MinIntervalRatio)
+				maxAllowed := time.Duration(float64(tt.retryInterval) * (1.0 + JitterPercentage))
+				if interval < minAllowed || interval > maxAllowed {
+					t.Errorf("Interval %v is outside expected range [%v, %v]", interval, minAllowed, maxAllowed)
+				}
+			}
+		})
+	}
+}
+
+// TestSession_calculateRetryIntervalWithJitter_Concurrency は並行アクセステスト
+func TestSession_calculateRetryIntervalWithJitter_Concurrency(t *testing.T) {
+	session := &Session{
+		RetryInterval: 1 * time.Second,
+	}
+
+	const numGoroutines = 100
+	const numIterations = 10
+
+	var wg sync.WaitGroup
+	results := make(chan time.Duration, numGoroutines*numIterations)
+
+	// 複数のgoroutineから同時にアクセス
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < numIterations; j++ {
+				interval := session.calculateRetryIntervalWithJitter()
+				results <- interval
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(results)
+
+	// 結果を収集
+	var intervals []time.Duration
+	for interval := range results {
+		intervals = append(intervals, interval)
+	}
+
+	// すべての結果が有効な範囲内にあることを確認
+	baseInterval := session.RetryInterval
+	minAllowed := time.Duration(float64(baseInterval) * MinIntervalRatio)
+	maxAllowed := time.Duration(float64(baseInterval) * (1.0 + JitterPercentage))
+
+	for i, interval := range intervals {
+		if interval < minAllowed || interval > maxAllowed {
+			t.Errorf("Interval %d (%v) is outside expected range [%v, %v]", i, interval, minAllowed, maxAllowed)
+		}
+	}
+
+	// 結果の多様性を確認（すべて同じでないことを確認）
+	uniqueValues := make(map[time.Duration]bool)
+	for _, interval := range intervals {
+		uniqueValues[interval] = true
+	}
+
+	// 少なくとも10個の異なる値があることを期待
+	if len(uniqueValues) < 10 {
+		t.Errorf("Expected at least 10 unique values, got %d", len(uniqueValues))
+	}
+
+	t.Logf("Generated %d unique values from %d total calls", len(uniqueValues), len(intervals))
+}
+
+// TestSession_calculateRetryIntervalWithJitter_ThreadSafety はスレッドセーフ性のテスト
+func TestSession_calculateRetryIntervalWithJitter_ThreadSafety(t *testing.T) {
+	session := &Session{
+		RetryInterval: 500 * time.Millisecond,
+	}
+
+	const numGoroutines = 50
+	const numIterations = 100
+
+	var wg sync.WaitGroup
+	errors := make(chan error, numGoroutines*numIterations)
+
+	// 複数のgoroutineから同時に大量アクセス
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func(routineID int) {
+			defer wg.Done()
+			for j := 0; j < numIterations; j++ {
+				interval := session.calculateRetryIntervalWithJitter()
+
+				// 基本的な妥当性チェック
+				if interval <= 0 {
+					errors <- fmt.Errorf("goroutine %d iteration %d: got non-positive interval %v", routineID, j, interval)
+					return
+				}
+
+				maxExpected := time.Duration(float64(session.RetryInterval) * (1.0 + JitterPercentage))
+				if interval > maxExpected*2 { // 異常に大きな値でないことを確認
+					errors <- fmt.Errorf("goroutine %d iteration %d: got unexpectedly large interval %v", routineID, j, interval)
+					return
+				}
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	close(errors)
+
+	// エラーがないことを確認
+	for err := range errors {
+		t.Error(err)
 	}
 }


### PR DESCRIPTION
## Summary

This PR implements jitter mechanisms to address excessive UDP retransmissions that were causing ECHONET Lite devices to be incorrectly marked as offline due to network congestion and synchronized retry storms.

## Changes Made

### 1. Retry Interval Jitter (`Session.go`)
- Added `calculateRetryIntervalWithJitter()` function with ±30% jitter
- Applied jitter to both `StartGetPropertiesWithRetry()` and `sendRequestWithContext()`
- Prevents synchronized retransmissions across multiple goroutines
- Includes minimum interval guarantee (50% of base interval)

### 2. Same-IP Rate Limiting Improvements (`handler_communication.go`)
- Replaced linear delay with exponential backoff (up to 5x multiplier)
- Added ±30% jitter to same-IP request spacing
- Reduced base delay from 100ms to 50ms while adding randomization
- Prevents request storms when multiple devices share the same IP address

### 3. Test Coverage
- Added comprehensive test suite (`Session_jitter_test.go`)
- Tests verify jitter range, minimum guarantees, and randomization

## Test Plan

- [x] All existing Go tests pass (`go test ./...`)
- [x] Web UI tests pass (`npm run test`)
- [x] Code formatting and linting checks pass
- [x] Build verification successful (`go build`, `npm run build`)
- [x] New jitter functionality covered by unit tests

## Benefits

- **Prevents "thundering herd" problem**: Multiple goroutines no longer retry simultaneously
- **Reduces network congestion**: Especially beneficial for devices hosting multiple ECHONET Lite instances
- **Improves reliability**: Fewer false offline notifications due to temporary network congestion
- **Standard networking practice**: Similar to Ethernet collision avoidance protocols

## Technical Details

The implementation follows networking best practices by introducing randomization to break up synchronized behaviors that can cause network congestion. The jitter values are carefully tuned to provide sufficient spreading while maintaining responsive retry behavior.

🤖 Generated with [Claude Code](https://claude.ai/code)