### PR TITLE
fix: implement notification channel fanout to resolve debugoffline toggle issue

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,6 +18,7 @@
     "epcs",
     "ESVINF",
     "ESVINFC",
+    "fanout",
     "findstr",
     "firewalld",
     "frontends",

--- a/echonet_lite/handler/ECHONETLiteHandler.go
+++ b/echonet_lite/handler/ECHONETLiteHandler.go
@@ -207,9 +207,11 @@ func NewECHONETLiteHandler(ctx context.Context, options ECHONETLieHandlerOptions
 	session.OnReceive(comm.onReceiveMessage)
 
 	// NotificationCh を中継用にラップし、タイムアウト時にオフライン状態を設定
+	// SubscribeNotifications を使用して専用チャンネルを取得
 	wrappedCh := make(chan DeviceNotification, 100)
+	subscribedCh := core.SubscribeNotifications(100)
 	go func() {
-		for ev := range core.NotificationCh {
+		for ev := range subscribedCh {
 			if ev.Type == DeviceTimeout {
 				// デバイスをオフラインに設定
 				data.SetOffline(ev.Device, true)

--- a/echonet_lite/handler/handler_core.go
+++ b/echonet_lite/handler/handler_core.go
@@ -53,22 +53,25 @@ func (c *HandlerCore) Close() error {
 		c.OperationTracker.Stop()
 	}
 
-	// コンテキストをキャンセル
+	// コンテキストをキャンセルしてfanoutNotifications()の終了をシグナル
 	if c.cancel != nil {
 		c.cancel()
 	}
 
-	// 通知チャネルを閉じる
+	// 通知チャネルを閉じる（これによりfanoutNotifications()が終了する）
 	if c.NotificationCh != nil {
 		close(c.NotificationCh)
 	}
+
+	// fanoutNotifications()の終了を少し待つ
+	time.Sleep(10 * time.Millisecond)
 
 	// プロパティ変化通知チャネルを閉じる
 	if c.PropertyChangeCh != nil {
 		close(c.PropertyChangeCh)
 	}
 
-	// 購読者チャンネルを閉じる
+	// 購読者チャンネルを閉じる（fanoutNotifications()終了後なので安全）
 	c.subscribersMutex.Lock()
 	for _, subscriber := range c.notificationSubscribers {
 		close(subscriber)

--- a/echonet_lite/handler/handler_core.go
+++ b/echonet_lite/handler/handler_core.go
@@ -4,17 +4,20 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"sync"
 	"time"
 )
 
 // HandlerCore は、ECHONETLiteHandlerのコア機能を担当する構造体
 type HandlerCore struct {
-	ctx              context.Context                 // コンテキスト
-	cancel           context.CancelFunc              // コンテキストのキャンセル関数
-	NotificationCh   chan DeviceNotification         // デバイス通知用チャネル
-	PropertyChangeCh chan PropertyChangeNotification // プロパティ変化通知用チャネル
-	Debug            bool                            // デバッグモード
-	OperationTracker *OperationTracker               // 操作追跡システム
+	ctx                     context.Context                 // コンテキスト
+	cancel                  context.CancelFunc              // コンテキストのキャンセル関数
+	NotificationCh          chan DeviceNotification         // デバイス通知用チャネル（内部用）
+	PropertyChangeCh        chan PropertyChangeNotification // プロパティ変化通知用チャネル
+	Debug                   bool                            // デバッグモード
+	OperationTracker        *OperationTracker               // 操作追跡システム
+	notificationSubscribers []chan DeviceNotification       // 通知購読者のリスト
+	subscribersMutex        sync.RWMutex                    // 購読者リストの保護
 }
 
 // NewHandlerCore は、HandlerCoreの新しいインスタンスを作成する
@@ -27,14 +30,20 @@ func NewHandlerCore(ctx context.Context, cancel context.CancelFunc, debug bool) 
 	operationTracker := NewOperationTracker(ctx, 5*time.Second)
 	operationTracker.Start()
 
-	return &HandlerCore{
-		ctx:              ctx,
-		cancel:           cancel,
-		NotificationCh:   notificationCh,
-		PropertyChangeCh: propertyChangeCh,
-		Debug:            debug,
-		OperationTracker: operationTracker,
+	core := &HandlerCore{
+		ctx:                     ctx,
+		cancel:                  cancel,
+		NotificationCh:          notificationCh,
+		PropertyChangeCh:        propertyChangeCh,
+		Debug:                   debug,
+		OperationTracker:        operationTracker,
+		notificationSubscribers: make([]chan DeviceNotification, 0),
 	}
+
+	// ファンアウト処理を開始
+	go core.fanoutNotifications()
+
+	return core
 }
 
 // Close は、HandlerCoreのリソースを解放する
@@ -59,6 +68,14 @@ func (c *HandlerCore) Close() error {
 		close(c.PropertyChangeCh)
 	}
 
+	// 購読者チャンネルを閉じる
+	c.subscribersMutex.Lock()
+	for _, subscriber := range c.notificationSubscribers {
+		close(subscriber)
+	}
+	c.notificationSubscribers = nil
+	c.subscribersMutex.Unlock()
+
 	return nil
 }
 
@@ -78,7 +95,7 @@ func (c *HandlerCore) notify(notification DeviceNotification) {
 		// 送信成功
 	default:
 		// チャンネルがブロックされている場合は無視
-		slog.Warn("通知チャネルがブロックされています", "notificationType", notification.Type, "device", notification.Device.Specifier())
+		slog.Warn("HandlerCore.notify: 通知チャネルがブロックされています", "notificationType", notification.Type, "device", notification.Device.Specifier())
 	}
 }
 
@@ -160,5 +177,44 @@ func (c *HandlerCore) StartEventRelayLoop(deviceEventCh <-chan DeviceEvent, sess
 func (c *HandlerCore) DebugLog(format string, args ...interface{}) {
 	if c.Debug {
 		fmt.Printf(format+"\n", args...)
+	}
+}
+
+// SubscribeNotifications は、通知を受信するためのチャンネルを作成して返す
+func (c *HandlerCore) SubscribeNotifications(bufferSize int) <-chan DeviceNotification {
+	ch := make(chan DeviceNotification, bufferSize)
+	c.subscribersMutex.Lock()
+	c.notificationSubscribers = append(c.notificationSubscribers, ch)
+	c.subscribersMutex.Unlock()
+	return ch
+}
+
+// fanoutNotifications は、内部NotificationChから購読者へ通知を配信する
+func (c *HandlerCore) fanoutNotifications() {
+	for {
+		select {
+		case notification, ok := <-c.NotificationCh:
+			if !ok {
+				// チャンネルが閉じられた場合は終了
+				return
+			}
+
+			// 全購読者に通知を配信
+			c.subscribersMutex.RLock()
+			for _, subscriber := range c.notificationSubscribers {
+				select {
+				case subscriber <- notification:
+					// 送信成功
+				default:
+					// バッファがフルの場合はスキップ（データロスを防ぐため）
+					slog.Warn("通知購読者のバッファがフルです", "notificationType", notification.Type, "device", notification.Device.Specifier())
+				}
+			}
+			c.subscribersMutex.RUnlock()
+
+		case <-c.ctx.Done():
+			// コンテキストがキャンセルされた場合は終了
+			return
+		}
 	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -46,8 +46,10 @@ func NewServer(ctx context.Context, cfg *config.Config) (*Server, error) {
 	liteHandler.StartMainLoop()
 
 	// 通知を監視するゴルーチン
+	// SubscribeNotifications を使用して専用チャンネルを取得
+	serverNotificationCh := liteHandler.GetCore().SubscribeNotifications(100)
 	go func() {
-		for notification := range liteHandler.NotificationCh {
+		for notification := range serverNotificationCh {
 			device := liteHandler.DeviceStringWithAlias(notification.Device)
 
 			switch notification.Type {


### PR DESCRIPTION
## Summary
- Fixed debugoffline command toggle problem that wasn't working reliably
- Resolved unstable Web UI real-time notifications  
- Implemented notification channel fanout pattern to eliminate goroutine competition

## Problem Analysis
Multiple goroutines were competing for the same `NotificationCh`:
- `server.go` (console output)
- `websocket_server.go` (Web UI broadcast) 
- `ECHONETLiteHandler` (internal processing)

Since Go channels consume messages when read, notifications were randomly distributed among consumers, causing:
- `debugoffline` toggle failures (`IsOfflineDevice` returning stale state)
- Inconsistent Web UI real-time updates (notifications arriving sporadically)
- Missing console output for some device events

## Solution
Implemented `SubscribeNotifications` pattern in `HandlerCore`:
- Added `fanoutNotifications()` goroutine to distribute all notifications to all subscribers
- Each consumer gets dedicated channel via `SubscribeNotifications(bufferSize)`
- All subscribers now receive all notifications reliably without competition

## Changes Made
- **HandlerCore**: Added `SubscribeNotifications` method and internal fanout logic
- **ECHONETLiteHandler**: Modified to use `SubscribeNotifications` instead of direct channel access
- **server.go**: Updated to use dedicated notification channel
- **websocket_server.go**: Updated to use dedicated notification channel  
- **Cleanup**: Removed debug prints

## Test Results
- ✅ Go: `fmt`, `vet`, `test`, `build` all passed
- ✅ Web UI: `lint`, `typecheck`, `test`, `build` all passed
- ✅ Manual testing confirmed debugoffline toggle now works consistently
- ✅ Web UI real-time notifications working reliably

🤖 Generated with [Claude Code](https://claude.ai/code)