### PR TITLE
fix: improve offline device visibility in dark mode

### DIFF
--- a/web/src/components/DeviceCard.tsx
+++ b/web/src/components/DeviceCard.tsx
@@ -67,7 +67,7 @@ export function DeviceCard({
 
   return (
     <Card 
-      className={`transition-all duration-200 w-full max-w-sm flex flex-col ${device.isOffline ? 'opacity-60' : ''}`} 
+      className={`transition-all duration-200 w-full max-w-sm flex flex-col relative ${device.isOffline ? 'after:absolute after:inset-0 after:bg-background/60 after:pointer-events-none after:rounded-lg' : ''}`} 
       data-testid={`device-card-${device.ip}-${device.eoj}`}
     >
       <CardHeader className="pb-2 px-3 pt-3">
@@ -96,7 +96,7 @@ export function DeviceCard({
               </p>
             )}
           </div>
-          <div className="flex items-center gap-1 shrink-0">
+          <div className="flex items-center gap-1 shrink-0 relative z-10">
             {onUpdateProperties && (
               <Button
                 variant="ghost"
@@ -115,7 +115,7 @@ export function DeviceCard({
                 <Button
                   variant="ghost"
                   size="sm"
-                  className="h-6 w-6 p-0 text-destructive hover:text-destructive"
+                  className="h-6 w-6 p-0 text-destructive hover:text-destructive hover:bg-destructive/10"
                   title="Delete offline device"
                   disabled={isDeletingDevice || !isConnected}
                   data-testid="delete-device-button"

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -42,7 +42,7 @@
     --color-primary-foreground: hsl(240 5.9% 10%);
     --color-secondary: hsl(240 3.7% 15.9%);
     --color-secondary-foreground: hsl(0 0% 98%);
-    --color-destructive: hsl(0 62.8% 30.6%);
+    --color-destructive: hsl(0 75% 45%);
     --color-destructive-foreground: hsl(0 0% 98%);
     --color-muted: hsl(240 3.7% 15.9%);
     --color-muted-foreground: hsl(240 5% 64.9%);
@@ -85,4 +85,5 @@
     touch-action: manipulation;
   }
 }
+
 


### PR DESCRIPTION
## Summary
- Enhanced delete button visibility for offline devices in dark mode
- Replaced opacity-based fading with overlay approach for better UX
- Added hover effects for better interactive feedback

## Changes
1. **Dark mode destructive color adjustment**: Changed from `hsl(0 62.8% 30.6%)` to `hsl(0 75% 45%)` for improved contrast
2. **Overlay-based fading**: Replaced `opacity-40` on entire card with semi-transparent overlay to preserve button visibility
3. **Z-index positioning**: Ensured action buttons (refresh/delete) remain above the overlay
4. **Hover state enhancement**: Added `hover:bg-destructive/10` for visual feedback

## Problem Solved
Previously, when a device went offline, the entire card would fade to 60% opacity, making the delete button hard to see in dark mode. The new approach uses a pseudo-element overlay, allowing the card content to appear faded while keeping action buttons fully visible.

## Test Plan
- [x] Verified offline devices show faded appearance in both light and dark modes
- [x] Confirmed delete button remains fully visible with strong red color
- [x] Tested hover states work correctly on action buttons
- [x] All existing tests pass (npm run test)
- [x] No linting or type errors

🤖 Generated with [Claude Code](https://claude.ai/code)