### PR TITLE
fix: suppress connection reset by peer errors in logs

### DIFF
--- a/server/transport.go
+++ b/server/transport.go
@@ -170,7 +170,8 @@ func isConnectionClosedError(err error) bool {
 	return websocket.IsCloseError(err, websocket.CloseGoingAway, websocket.CloseAbnormalClosure, websocket.CloseNoStatusReceived) ||
 		strings.Contains(err.Error(), "close sent") ||
 		strings.Contains(err.Error(), "use of closed network connection") ||
-		strings.Contains(err.Error(), "broken pipe")
+		strings.Contains(err.Error(), "broken pipe") ||
+		strings.Contains(err.Error(), "connection reset by peer")
 }
 
 // removeClient safely removes a client from the transport and calls the disconnect handler.


### PR DESCRIPTION
## Summary
- Added 'connection reset by peer' to the `isConnectionClosedError` function to properly handle client disconnections
- This prevents unnecessary error logs when clients disconnect abruptly

## Test plan
✅ All tests pass:
- Go tests: all packages pass
- Web UI: lint, typecheck, tests, and build all succeed

🤖 Generated with Claude Code