### PR TITLE
fix: improve connection error handling in message handler

### DIFF
--- a/server/transport.go
+++ b/server/transport.go
@@ -326,7 +326,8 @@ func (t *DefaultWebSocketTransport) handleWebSocket(w http.ResponseWriter, r *ht
 			if err := t.messageHandler(connID, message); err != nil {
 				// Check if this is a client disconnection error
 				errStr := err.Error()
-				if !(strings.Contains(errStr, "client with ID") && strings.Contains(errStr, "not found")) {
+				if !isConnectionClosedError(err) &&
+					!(strings.Contains(errStr, "client with ID") && strings.Contains(errStr, "not found")) {
 					// Only log non-disconnection errors
 					slog.Error("Error in message handler", "err", err)
 				}


### PR DESCRIPTION
## Summary
- Applied `isConnectionClosedError` function to the message handler error checking
- This properly handles network-level disconnection errors (broken pipe, connection reset by peer)
- Kept the existing application-level error check for 'client with ID not found'

## Background
After the previous fix that added 'connection reset by peer' to `isConnectionClosedError`, we still saw errors being logged from the message handler. This was because the message handler was not using the `isConnectionClosedError` function.

## Test plan
✅ All tests pass:
- Go tests: all packages pass
- Web UI: lint, typecheck, tests, and build all succeed

🤖 Generated with Claude Code