### PR TITLE
feat: implement special display for NodeProfile SelfNodeInstanceListS property

### DIFF
--- a/web/src/components/DeviceCard.tsx
+++ b/web/src/components/DeviceCard.tsx
@@ -185,6 +185,9 @@ export function DeviceCard({
                     propertyDescriptions={propertyDescriptions}
                     classCode={classCode}
                     isConnected={isConnected && !device.isOffline}
+                    allDevices={devices}
+                    aliases={aliases}
+                    getDeviceClassCode={getDeviceClassCode}
                   />
                 ))
               ) : (
@@ -200,6 +203,9 @@ export function DeviceCard({
                     propertyDescriptions={propertyDescriptions}
                     classCode={classCode}
                     isConnected={isConnected && !device.isOffline}
+                    allDevices={devices}
+                    aliases={aliases}
+                    getDeviceClassCode={getDeviceClassCode}
                   />
                 ))
               )}
@@ -224,6 +230,9 @@ export function DeviceCard({
                     propertyDescriptions={propertyDescriptions}
                     classCode={classCode}
                     isConnected={isConnected && !device.isOffline}
+                    allDevices={devices}
+                    aliases={aliases}
+                    getDeviceClassCode={getDeviceClassCode}
                   />
                 ))}
               </div>
@@ -247,6 +256,9 @@ export function DeviceCard({
                   propertyDescriptions={propertyDescriptions}
                   classCode={classCode}
                   isConnected={isConnected}
+                  allDevices={devices}
+                  aliases={aliases}
+                  getDeviceClassCode={getDeviceClassCode}
                 />
               ))}
             </div>

--- a/web/src/components/GroupMemberEditor.tsx
+++ b/web/src/components/GroupMemberEditor.tsx
@@ -1,10 +1,9 @@
 import { useState } from 'react';
 import { Card, CardContent } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { GripVertical, Plus, Minus, Users } from 'lucide-react';
+import { Users } from 'lucide-react';
+import { SimpleDeviceCard } from '@/components/SimpleDeviceCard';
 import { getDeviceAliases } from '@/libs/deviceIdHelper';
-import { formatPropertyValue, getPropertyDescriptor } from '@/libs/propertyHelper';
 import type { Device, DeviceAlias, PropertyDescriptionData } from '@/hooks/types';
 
 interface GroupMemberEditorProps {
@@ -176,99 +175,27 @@ export function GroupMemberEditor({
   };
 
   const renderDeviceCard = (deviceKey: string, device: Device, isMember: boolean) => {
-    const { aliases: deviceAliases } = getDeviceAliases(device, allDevices, aliases);
-    const locationProperty = device.properties['81'];
-    
-    // Get device class code and property descriptor like DeviceCard does
-    const classCode = getDeviceClassCode(device);
-    const propertyDescriptor = getPropertyDescriptor('81', propertyDescriptions, classCode);
-    
-    
-    // Format installation location using the same method as DeviceCard
-    const locationDisplay = locationProperty 
-      ? formatPropertyValue(locationProperty, propertyDescriptor)
-      : '';
-    
-    
-    // Use device.name for better readability (e.g., "0EF0[Node Profile]")
-    const deviceDisplayName = device.name || device.eoj;
-    
     return (
-      <Card
+      <SimpleDeviceCard
         key={deviceKey}
-        data-testid={`device-card-${deviceKey.replace(/\s+/g, '-')}`}
-        draggable={!isLoading}
-        onDragStart={(e) => handleDragStart(e, deviceKey)}
+        deviceKey={deviceKey}
+        device={device}
+        allDevices={allDevices}
+        aliases={aliases}
+        propertyDescriptions={propertyDescriptions}
+        getDeviceClassCode={getDeviceClassCode}
+        isDraggable={true}
+        onDragStart={handleDragStart}
         onDragEnd={handleDragEnd}
-        className={`transition-opacity ${
-          draggingDevice === deviceKey ? 'opacity-50' : ''
-        } ${isLoading ? 'cursor-not-allowed opacity-50' : ''}`}
-      >
-        <CardContent className="p-3">
-          <div className="flex items-start gap-2">
-            <GripVertical className="h-4 w-4 text-muted-foreground mt-0.5 flex-shrink-0" />
-            <div className="flex-1 min-w-0 space-y-2">
-              {/* Primary identification */}
-              <div className="space-y-1">
-                {deviceAliases.length > 0 ? (
-                  <div className="text-sm font-medium">{deviceAliases[0]}</div>
-                ) : (
-                  <div className="text-sm font-medium">{deviceDisplayName}</div>
-                )}
-                {deviceAliases.length > 0 ? (
-                  <div className="text-xs text-muted-foreground">{deviceDisplayName}</div>
-                ) : (
-                  <div className="text-xs text-muted-foreground">{device.ip} {device.eoj}</div>
-                )}
-                {/* Installation location display */}
-                {locationDisplay && (
-                  <div className="text-xs text-muted-foreground">
-                    設置場所: {locationDisplay}
-                  </div>
-                )}
-              </div>
-              
-              {/* Device info badges */}
-              <div className="flex flex-wrap gap-1">
-                {deviceAliases.length > 1 && (
-                  <Badge variant="outline" className="text-xs">
-                    +{deviceAliases.length - 1}
-                  </Badge>
-                )}
-              </div>
-            </div>
-            
-            {/* Add/Remove Button */}
-            <div className="flex-shrink-0">
-              {isMember ? (
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => handleRemoveDevice(deviceKey)}
-                  disabled={isLoading || !isConnected}
-                  className="h-8 w-8 p-0"
-                  title="グループから削除"
-                  data-testid={`remove-device-${deviceKey.replace(/\s+/g, '-')}`}
-                >
-                  <Minus className="h-4 w-4" />
-                </Button>
-              ) : (
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => handleAddDevice(deviceKey)}
-                  disabled={isLoading || !isConnected}
-                  className="h-8 w-8 p-0"
-                  title="グループに追加"
-                  data-testid={`add-device-${deviceKey.replace(/\s+/g, '-')}`}
-                >
-                  <Plus className="h-4 w-4" />
-                </Button>
-              )}
-            </div>
-          </div>
-        </CardContent>
-      </Card>
+        isDragging={draggingDevice === deviceKey}
+        isLoading={isLoading}
+        actionButton={{
+          type: isMember ? 'remove' : 'add',
+          onClick: () => isMember ? handleRemoveDevice(deviceKey) : handleAddDevice(deviceKey),
+          title: isMember ? "グループから削除" : "グループに追加",
+          disabled: isLoading || !isConnected
+        }}
+      />
     );
   };
 

--- a/web/src/components/PropertyEditor.tsx
+++ b/web/src/components/PropertyEditor.tsx
@@ -6,7 +6,7 @@ import { PropertyDisplay } from './PropertyDisplay';
 import { HexViewer } from './HexViewer';
 import { isPropertySettable, formatPropertyValue, shouldShowHexViewer } from '@/libs/propertyHelper';
 import { getCurrentLocale } from '@/libs/languageHelper';
-import type { PropertyDescriptor, PropertyValue, Device, PropertyDescriptionData } from '@/hooks/types';
+import type { PropertyDescriptor, PropertyValue, Device, PropertyDescriptionData, DeviceAlias } from '@/hooks/types';
 
 interface PropertyEditorProps {
   device: Device;
@@ -16,6 +16,10 @@ interface PropertyEditorProps {
   onPropertyChange: (target: string, epc: string, value: PropertyValue) => Promise<void>;
   propertyDescriptions?: Record<string, PropertyDescriptionData>;
   isConnected?: boolean;
+  allDevices?: Record<string, Device>;
+  aliases?: DeviceAlias;
+  getDeviceClassCode?: (device: Device) => string;
+  isCompact?: boolean;
 }
 
 export function PropertyEditor({ 
@@ -25,8 +29,13 @@ export function PropertyEditor({
   descriptor, 
   onPropertyChange,
   propertyDescriptions,
-  isConnected 
+  isConnected,
+  allDevices,
+  aliases,
+  getDeviceClassCode,
+  isCompact = false
 }: PropertyEditorProps) {
+  
   const deviceId = `${device.ip} ${device.eoj}`;
 
   const hasAliases = descriptor?.aliases && Object.keys(descriptor.aliases).length > 0;
@@ -80,6 +89,10 @@ export function PropertyEditor({
         epc={epc}
         propertyDescriptions={propertyDescriptions}
         device={device}
+        allDevices={allDevices}
+        aliases={aliases}
+        getDeviceClassCode={getDeviceClassCode}
+        isCompact={isCompact}
       />
     );
   }

--- a/web/src/components/PropertyMapDisplay.tsx
+++ b/web/src/components/PropertyMapDisplay.tsx
@@ -1,0 +1,111 @@
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { ChevronDown, ChevronRight } from 'lucide-react';
+import { HexViewer } from './HexViewer';
+import { formatPropertyValue, decodePropertyMap, getPropertyName, extractClassCodeFromEOJ } from '@/libs/propertyHelper';
+import { getCurrentLocale } from '@/libs/languageHelper';
+import type { PropertyValue, PropertyDescriptor, PropertyDescriptionData, Device } from '@/hooks/types';
+
+interface PropertyMapDisplayProps {
+  currentValue: PropertyValue;
+  descriptor?: PropertyDescriptor;
+  propertyDescriptions?: Record<string, PropertyDescriptionData>;
+  device?: Device;
+}
+
+export function PropertyMapDisplay({ 
+  currentValue, 
+  descriptor,
+  propertyDescriptions,
+  device
+}: PropertyMapDisplayProps) {
+  const [showPropertyMap, setShowPropertyMap] = useState(false);
+  const currentLang = getCurrentLocale();
+  
+  // Parse property map
+  const parsePropertyMap = () => {
+    if (!currentValue.EDT || !propertyDescriptions || !device) return null;
+    
+    const epcs = decodePropertyMap(currentValue.EDT);
+    if (!epcs) return null;
+    
+    const classCode = extractClassCodeFromEOJ(device.eoj);
+    const properties = epcs.map(epc => ({
+      epc,
+      description: getPropertyName(epc, propertyDescriptions, classCode, currentLang)
+    }));
+    
+    // Get property count from the original EDT data
+    try {
+      const mapBytes = atob(currentValue.EDT);
+      const propertyCount = mapBytes.length > 0 ? mapBytes.charCodeAt(0) : 0;
+      return { propertyCount, properties };
+    } catch {
+      return { propertyCount: epcs.length, properties };
+    }
+  };
+  
+  const formattedValue = formatPropertyValue(currentValue, descriptor, currentLang);
+  const mapData = parsePropertyMap();
+  
+  if (!mapData) {
+    return (
+      <div className="relative">
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-medium">
+            {formattedValue}
+          </span>
+          <HexViewer 
+            canShowHexViewer={true} 
+            currentValue={currentValue}
+          />
+        </div>
+      </div>
+    );
+  }
+  
+  return (
+    <div className="relative">
+      <div className="flex items-center gap-2">
+        <span className="text-sm font-medium">
+          {formattedValue} ({mapData.propertyCount})
+        </span>
+        <Button
+          variant={showPropertyMap ? "default" : "outline"}
+          size="sm"
+          onClick={() => setShowPropertyMap(!showPropertyMap)}
+          className="h-6 w-6 p-0"
+          title={showPropertyMap ? "Hide property details" : "Show property details"}
+        >
+          {showPropertyMap ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
+        </Button>
+        <HexViewer 
+          canShowHexViewer={true} 
+          currentValue={currentValue}
+        />
+      </div>
+      {showPropertyMap && (
+        <div className="absolute top-full left-0 right-0 mt-1 bg-background border rounded shadow-md z-20 min-w-max">
+          <div className="p-2 space-y-1">
+            {mapData.properties.map((property) => (
+              <div
+                key={property.epc}
+                className="flex items-center gap-2 text-sm"
+              >
+                <span className="font-mono text-xs bg-muted px-1 py-0.5 rounded">
+                  {property.epc}
+                </span>
+                <span>{property.description}</span>
+              </div>
+            ))}
+            {mapData.properties.length === 0 && (
+              <div className="text-sm text-muted-foreground">
+                No properties in this map
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/PropertyRow.tsx
+++ b/web/src/components/PropertyRow.tsx
@@ -3,7 +3,7 @@ import { PropertyDisplay } from './PropertyDisplay';
 import { getPropertyName, getPropertyDescriptor, isPropertySettable } from '@/libs/propertyHelper';
 import { isSensorProperty, getSensorIcon, getSensorIconColor } from '@/libs/sensorPropertyHelper';
 import { getCurrentLocale } from '@/libs/languageHelper';
-import type { Device, PropertyValue, PropertyDescriptionData } from '@/hooks/types';
+import type { Device, PropertyValue, PropertyDescriptionData, DeviceAlias } from '@/hooks/types';
 
 interface PropertyRowProps {
   device: Device;
@@ -14,6 +14,9 @@ interface PropertyRowProps {
   propertyDescriptions: Record<string, PropertyDescriptionData>;
   classCode: string;
   isConnected?: boolean;
+  allDevices?: Record<string, Device>;
+  aliases?: DeviceAlias;
+  getDeviceClassCode?: (device: Device) => string;
 }
 
 export function PropertyRow({
@@ -24,8 +27,12 @@ export function PropertyRow({
   onPropertyChange,
   propertyDescriptions,
   classCode,
-  isConnected
+  isConnected,
+  allDevices,
+  aliases,
+  getDeviceClassCode
 }: PropertyRowProps) {
+  
   const currentLang = getCurrentLocale();
   const propertyName = getPropertyName(epc, propertyDescriptions, classCode, currentLang);
   const propertyDescriptor = getPropertyDescriptor(epc, propertyDescriptions, classCode, currentLang);
@@ -57,6 +64,10 @@ export function PropertyRow({
               onPropertyChange={onPropertyChange}
               propertyDescriptions={propertyDescriptions}
               isConnected={isConnected}
+              allDevices={allDevices}
+              aliases={aliases}
+              getDeviceClassCode={getDeviceClassCode}
+              isCompact={isCompact}
             />
           ) : (
             <PropertyDisplay
@@ -65,6 +76,10 @@ export function PropertyRow({
               epc={epc}
               propertyDescriptions={propertyDescriptions}
               device={device}
+              allDevices={allDevices}
+              aliases={aliases}
+              getDeviceClassCode={getDeviceClassCode}
+              isCompact={isCompact}
             />
           )}
         </div>
@@ -90,6 +105,10 @@ export function PropertyRow({
                 onPropertyChange={onPropertyChange}
                 propertyDescriptions={propertyDescriptions}
                 isConnected={isConnected}
+                allDevices={allDevices}
+                aliases={aliases}
+                getDeviceClassCode={getDeviceClassCode}
+                isCompact={isCompact}
               />
             ) : (
               <PropertyDisplay
@@ -98,6 +117,10 @@ export function PropertyRow({
                 epc={epc}
                 propertyDescriptions={propertyDescriptions}
                 device={device}
+                allDevices={allDevices}
+                aliases={aliases}
+                getDeviceClassCode={getDeviceClassCode}
+                isCompact={isCompact}
               />
             )}
           </div>
@@ -121,6 +144,10 @@ export function PropertyRow({
             onPropertyChange={onPropertyChange}
             propertyDescriptions={propertyDescriptions}
             isConnected={isConnected}
+            allDevices={allDevices}
+            aliases={aliases}
+            getDeviceClassCode={getDeviceClassCode}
+            isCompact={isCompact}
           />
         </div>
       </div>

--- a/web/src/components/SelfNodeInstanceListSDisplay.tsx
+++ b/web/src/components/SelfNodeInstanceListSDisplay.tsx
@@ -1,0 +1,100 @@
+import { SimpleDeviceCard } from '@/components/SimpleDeviceCard';
+import { HexViewer } from '@/components/HexViewer';
+import { decodeInstanceList } from '@/libs/propertyHelper';
+import type { PropertyValue, Device, DeviceAlias, PropertyDescriptionData } from '@/hooks/types';
+
+interface SelfNodeInstanceListSDisplayProps {
+  currentValue: PropertyValue;
+  device: Device;
+  allDevices: Record<string, Device>;
+  aliases: DeviceAlias;
+  propertyDescriptions: Record<string, PropertyDescriptionData>;
+  getDeviceClassCode: (device: Device) => string;
+  isCompact?: boolean;
+}
+
+export function SelfNodeInstanceListSDisplay({
+  currentValue,
+  device,
+  allDevices,
+  aliases,
+  propertyDescriptions,
+  getDeviceClassCode,
+  isCompact = false,
+}: SelfNodeInstanceListSDisplayProps) {
+  // Decode the instance list from EDT
+  const instances = currentValue.EDT ? decodeInstanceList(currentValue.EDT) : null;
+  
+  if (!instances) {
+    return (
+      <div className="relative">
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-medium">
+            Invalid instance list data
+          </span>
+          <HexViewer 
+            canShowHexViewer={true} 
+            currentValue={currentValue}
+          />
+        </div>
+      </div>
+    );
+  }
+  
+  // Create device keys by combining IP with EOJ
+  const deviceCards = instances.map((instance, index) => {
+    const eoj = `${instance.classCode}:${parseInt(instance.instanceCode, 16)}`;
+    const deviceKey = `${device.ip} ${eoj}`;
+    const targetDevice = allDevices[deviceKey];
+    
+    if (!targetDevice) {
+      // Device not found in current devices list
+      return (
+        <div key={index} className={`p-2 border rounded text-muted-foreground ${
+          isCompact ? "text-xs" : "text-sm"
+        }`}>
+          <div className="font-mono">{eoj}</div>
+          <div className={isCompact ? "text-xs" : "text-xs"}>Device not found</div>
+        </div>
+      );
+    }
+    
+    return (
+      <SimpleDeviceCard
+        key={deviceKey}
+        deviceKey={deviceKey}
+        device={targetDevice}
+        allDevices={allDevices}
+        aliases={aliases}
+        propertyDescriptions={propertyDescriptions}
+        getDeviceClassCode={getDeviceClassCode}
+        isDraggable={false}
+        className={isCompact ? "text-xs w-32 flex-shrink-0" : ""}
+        isCompact={isCompact}
+      />
+    );
+  });
+  
+  return (
+    <div className={isCompact ? "space-y-1" : "space-y-2"}>
+      {/* Show header with count and hex viewer only in full mode */}
+      {!isCompact && (
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-medium">
+            Instance List ({instances.length})
+          </span>
+          <HexViewer 
+            canShowHexViewer={true} 
+            currentValue={currentValue}
+          />
+        </div>
+      )}
+      <div className={isCompact 
+        ? "flex flex-wrap gap-1 justify-end" 
+        : "grid gap-2 grid-cols-1"
+      }>
+        {deviceCards}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/SelfNodeInstanceListSDisplay.tsx
+++ b/web/src/components/SelfNodeInstanceListSDisplay.tsx
@@ -49,12 +49,16 @@ export function SelfNodeInstanceListSDisplay({
     
     if (!targetDevice) {
       // Device not found in current devices list
+      // Add debugging information for device key format issues
+      if (process.env.NODE_ENV === 'development') {
+        console.debug(`Device not found: expected "${deviceKey}", available keys:`, Object.keys(allDevices).slice(0, 3));
+      }
       return (
         <div key={index} className={`p-2 border rounded text-muted-foreground ${
           isCompact ? "text-xs" : "text-sm"
         }`}>
           <div className="font-mono">{eoj}</div>
-          <div className={isCompact ? "text-xs" : "text-xs"}>Device not found</div>
+          <div className={isCompact ? "text-xs" : "text-sm"}>Device not found</div>
         </div>
       );
     }

--- a/web/src/components/SimpleDeviceCard.tsx
+++ b/web/src/components/SimpleDeviceCard.tsx
@@ -90,9 +90,8 @@ export function SimpleDeviceCard({
               ) : null}
               {/* Installation location display */}
               {locationDisplay && (
-                <div className={`text-xs text-muted-foreground ${isCompact ? 'truncate' : ''}`}>
-                  <span className="sr-only">設置場所:</span>
-                  <span aria-label="Installation location">{locationDisplay}</span>
+                <div className={`text-xs text-muted-foreground ${isCompact ? 'truncate' : ''}`} aria-label="Installation location">
+                  設置場所: {locationDisplay}
                 </div>
               )}
             </div>

--- a/web/src/components/SimpleDeviceCard.tsx
+++ b/web/src/components/SimpleDeviceCard.tsx
@@ -1,0 +1,133 @@
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { GripVertical, Plus, Minus } from 'lucide-react';
+import { getDeviceAliases } from '@/libs/deviceIdHelper';
+import { formatPropertyValue, getPropertyDescriptor } from '@/libs/propertyHelper';
+import type { Device, DeviceAlias, PropertyDescriptionData } from '@/hooks/types';
+
+interface SimpleDeviceCardProps {
+  deviceKey: string;
+  device: Device;
+  allDevices: Record<string, Device>;
+  aliases: DeviceAlias;
+  propertyDescriptions: Record<string, PropertyDescriptionData>;
+  getDeviceClassCode: (device: Device) => string;
+  isDraggable?: boolean;
+  onDragStart?: (e: React.DragEvent, deviceKey: string) => void;
+  onDragEnd?: () => void;
+  isDragging?: boolean;
+  isLoading?: boolean;
+  actionButton?: {
+    type: 'add' | 'remove' | 'custom';
+    onClick: () => void;
+    icon?: React.ReactNode;
+    title?: string;
+    disabled?: boolean;
+  };
+  className?: string;
+  isCompact?: boolean;
+}
+
+export function SimpleDeviceCard({
+  deviceKey,
+  device,
+  allDevices,
+  aliases,
+  propertyDescriptions,
+  getDeviceClassCode,
+  isDraggable = false,
+  onDragStart,
+  onDragEnd,
+  isDragging = false,
+  isLoading = false,
+  actionButton,
+  className = '',
+  isCompact = false,
+}: SimpleDeviceCardProps) {
+  const { aliases: deviceAliases } = getDeviceAliases(device, allDevices, aliases);
+  const locationProperty = device.properties['81'];
+  
+  // Get device class code and property descriptor like original DeviceCard does
+  const classCode = getDeviceClassCode(device);
+  const propertyDescriptor = getPropertyDescriptor('81', propertyDescriptions, classCode);
+  
+  // Format installation location using the same method as original DeviceCard
+  const locationDisplay = locationProperty 
+    ? formatPropertyValue(locationProperty, propertyDescriptor)
+    : '';
+  
+  // Use device.name for better readability (e.g., "0EF0[Node Profile]")
+  const deviceDisplayName = device.name || device.eoj;
+  
+  return (
+    <Card
+      data-testid={`device-card-${deviceKey.replace(/\s+/g, '-')}`}
+      draggable={isDraggable && !isLoading}
+      onDragStart={isDraggable ? (e) => onDragStart?.(e, deviceKey) : undefined}
+      onDragEnd={isDraggable ? onDragEnd : undefined}
+      className={`transition-opacity overflow-hidden ${
+        isDragging ? 'opacity-50' : ''
+      } ${isLoading ? 'cursor-not-allowed opacity-50' : ''} ${className}`}
+    >
+      <CardContent className="p-3">
+        <div className="flex items-start gap-2">
+          {isDraggable && (
+            <GripVertical className="h-4 w-4 text-muted-foreground mt-0.5 flex-shrink-0" />
+          )}
+          <div className="flex-1 min-w-0 space-y-2">
+            {/* Primary identification */}
+            <div className="space-y-1">
+              {deviceAliases.length > 0 ? (
+                <div className={`text-sm font-medium ${isCompact ? 'truncate' : ''}`}>{deviceAliases[0]}</div>
+              ) : (
+                <div className={`text-sm font-medium ${isCompact ? 'truncate' : ''}`}>{deviceDisplayName}</div>
+              )}
+              {deviceAliases.length > 0 && !isCompact ? (
+                <div className={`text-xs text-muted-foreground ${isCompact ? 'truncate' : ''}`}>{deviceDisplayName}</div>
+              ) : !deviceAliases.length ? (
+                <div className={`text-xs text-muted-foreground ${isCompact ? 'truncate' : ''}`}>{device.ip} {device.eoj}</div>
+              ) : null}
+              {/* Installation location display */}
+              {locationDisplay && (
+                <div className={`text-xs text-muted-foreground ${isCompact ? 'truncate' : ''}`}>
+                  設置場所: {locationDisplay}
+                </div>
+              )}
+            </div>
+            
+            {/* Device info badges */}
+            <div className="flex flex-wrap gap-1">
+              {deviceAliases.length > 1 && (
+                <Badge variant="outline" className="text-xs">
+                  +{deviceAliases.length - 1}
+                </Badge>
+              )}
+            </div>
+          </div>
+          
+          {/* Action Button */}
+          {actionButton && (
+            <div className="flex-shrink-0">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={actionButton.onClick}
+                disabled={actionButton.disabled || isLoading}
+                className="h-8 w-8 p-0"
+                title={actionButton.title}
+                data-testid={`${actionButton.type}-device-${deviceKey.replace(/\s+/g, '-')}`}
+              >
+                {actionButton.icon || (
+                  actionButton.type === 'add' ? <Plus className="h-4 w-4" /> :
+                  actionButton.type === 'remove' ? <Minus className="h-4 w-4" /> :
+                  null
+                )}
+              </Button>
+            </div>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/web/src/components/SimpleDeviceCard.tsx
+++ b/web/src/components/SimpleDeviceCard.tsx
@@ -91,7 +91,8 @@ export function SimpleDeviceCard({
               {/* Installation location display */}
               {locationDisplay && (
                 <div className={`text-xs text-muted-foreground ${isCompact ? 'truncate' : ''}`}>
-                  設置場所: {locationDisplay}
+                  <span className="sr-only">設置場所:</span>
+                  <span aria-label="Installation location">{locationDisplay}</span>
                 </div>
               )}
             </div>

--- a/web/src/libs/deviceTypeHelper.ts
+++ b/web/src/libs/deviceTypeHelper.ts
@@ -13,6 +13,11 @@ export const ESSENTIAL_PROPERTIES = ['80'] as const; // Operation Status
  * Value: Array of EPC codes to display in compact view
  */
 export const DEVICE_PRIMARY_PROPERTIES: Record<string, string[]> = {
+  // Node Profile (0EF0)
+  '0EF0': [
+    'D6', // SelfNodeInstanceListS
+  ],
+
   // Home Air Conditioner (0130)
   '0130': [
     'BB', 'BA', // temperature, humidity


### PR DESCRIPTION
## Summary

This PR implements a specialized display component for ECHONET Lite NodeProfile devices' SelfNodeInstanceListS property (EPC D6), transforming raw EDT data into user-friendly device cards.

### Key Features

- **📦 Component Extraction**: Separated PropertyMapDisplay logic for better code organization
- **🎯 Specialized Display**: Added SelfNodeInstanceListSDisplay component for NodeProfile EPC D6
- **🎨 Device Cards**: Created SimpleDeviceCard for reusable device card functionality
- **📱 Responsive Layout**: 
  - Compact mode: Right-aligned, small cards with truncated text
  - Full mode: Grid layout with full text display
- **🔧 Data Processing**: Added decodeInstanceList helper to parse ECHONET instance list data
- **🎛️ Prop Enhancement**: Enhanced prop passing for device context throughout the component tree

### Technical Implementation

- **SelfNodeInstanceListSDisplay**: Decodes EDT data (3 bytes per EOJ) and renders device cards
- **SimpleDeviceCard**: Extracted from GroupMemberEditor with drag/drop and action button support
- **PropertyMapDisplay**: Separated from PropertyDisplay for cleaner code organization
- **Enhanced Props**: Added allDevices, aliases, getDeviceClassCode to PropertyDisplay/PropertyEditor chain

### Test Results

✅ **Go Backend**
- `go fmt ./...` - Clean
- `go vet ./...` - Clean  
- `go test ./...` - All tests pass
- `go build` - Success

✅ **Web Frontend**
- `npm run lint` - Clean
- `npm run typecheck` - Clean
- `npm run test` - 415 tests pass
- `npm run build` - Success

🤖 Generated with [Claude Code](https://claude.ai/code)