### PR TITLE
feat: add DeviceIcon and offline styling to SimpleDeviceCard

### DIFF
--- a/web/src/components/SimpleDeviceCard.test.tsx
+++ b/web/src/components/SimpleDeviceCard.test.tsx
@@ -1,0 +1,471 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SimpleDeviceCard } from './SimpleDeviceCard';
+import type { Device, DeviceAlias, PropertyDescriptionData } from '@/hooks/types';
+import * as deviceIdHelper from '@/libs/deviceIdHelper';
+import * as propertyHelper from '@/libs/propertyHelper';
+
+// Mock deviceIdHelper functions
+vi.mock('@/libs/deviceIdHelper', () => ({
+  getDeviceAliases: vi.fn(() => ({ 
+    aliases: [], 
+    deviceIdentifier: '192.168.1.100 0291:1' 
+  }))
+}));
+
+// Mock propertyHelper functions
+vi.mock('@/libs/propertyHelper', () => ({
+  formatPropertyValue: vi.fn((value) => value?.string || ''),
+  getPropertyDescriptor: vi.fn(() => ({ name: 'Installation location' }))
+}));
+
+// Mock DeviceIcon component
+vi.mock('@/components/DeviceIcon', () => ({
+  DeviceIcon: ({ device, classCode }: { device: Device; classCode: string }) => (
+    <div data-testid="device-icon" data-device={device.eoj} data-class-code={classCode}>
+      🏠
+    </div>
+  )
+}));
+
+describe('SimpleDeviceCard', () => {
+  const mockDevice: Device = {
+    ip: '192.168.1.100',
+    eoj: '0291:1',
+    name: 'Single Function Lighting',
+    id: undefined,
+    lastSeen: new Date().toISOString(),
+    properties: {
+      '80': { string: 'on' },
+      '81': { string: 'living' }
+    }
+  };
+
+  const mockDevices: Record<string, Device> = {
+    '192.168.1.100 0291:1': mockDevice
+  };
+
+  const mockAliases: DeviceAlias = {};
+
+  const mockPropertyDescriptions: Record<string, PropertyDescriptionData> = {
+    '': {
+      classCode: '',
+      properties: {
+        '80': { description: 'Operation Status' },
+        '81': { description: 'Installation Location' }
+      }
+    },
+    '0291': {
+      classCode: '0291',
+      properties: {
+        'B0': { description: 'Illuminance Level' }
+      }
+    }
+  };
+
+  const defaultProps = {
+    deviceKey: '192.168.1.100 0291:1',
+    device: mockDevice,
+    allDevices: mockDevices,
+    aliases: mockAliases,
+    propertyDescriptions: mockPropertyDescriptions,
+    getDeviceClassCode: vi.fn(() => '0291')
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset mocks to default behavior
+    vi.mocked(deviceIdHelper.getDeviceAliases).mockReturnValue({
+      aliases: [],
+      deviceIdentifier: '192.168.1.100 0291:1'
+    });
+    vi.mocked(propertyHelper.formatPropertyValue).mockImplementation((value) => value?.string || '');
+    vi.mocked(propertyHelper.getPropertyDescriptor).mockReturnValue({ description: 'Installation location' });
+  });
+
+  describe('Basic rendering', () => {
+    it('should render device card with basic information', () => {
+      render(<SimpleDeviceCard {...defaultProps} />);
+      
+      expect(screen.getByTestId('device-card-192.168.1.100-0291:1')).toBeInTheDocument();
+      expect(screen.getByText('Single Function Lighting')).toBeInTheDocument();
+    });
+
+    it('should render DeviceIcon with correct props', () => {
+      render(<SimpleDeviceCard {...defaultProps} />);
+      
+      const deviceIcon = screen.getByTestId('device-icon');
+      expect(deviceIcon).toBeInTheDocument();
+      expect(deviceIcon).toHaveAttribute('data-device', '0291:1');
+      expect(deviceIcon).toHaveAttribute('data-class-code', '0291');
+    });
+
+    it('should render device with IP and EOJ when no alias', () => {
+      render(<SimpleDeviceCard {...defaultProps} />);
+      
+      expect(screen.getByText('192.168.1.100 0291:1')).toBeInTheDocument();
+    });
+
+    it('should display alias when available', () => {
+      const mockGetDeviceAliases = vi.mocked(deviceIdHelper.getDeviceAliases);
+      mockGetDeviceAliases.mockReturnValue({
+        aliases: ['Living Room Light'],
+        deviceIdentifier: '192.168.1.100 0291:1'
+      });
+
+      render(<SimpleDeviceCard {...defaultProps} />);
+      
+      expect(screen.getByText('Living Room Light')).toBeInTheDocument();
+    });
+  });
+
+  describe('Null safety and error handling', () => {
+    it('should return null when device is null', () => {
+      const { container } = render(
+        <SimpleDeviceCard {...defaultProps} device={null as any} />
+      );
+      
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('should return null when getDeviceClassCode is null', () => {
+      const { container } = render(
+        <SimpleDeviceCard {...defaultProps} getDeviceClassCode={null as any} />
+      );
+      
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('should handle missing properties gracefully', () => {
+      const deviceWithoutProperties = {
+        ...mockDevice,
+        properties: undefined as any
+      };
+
+      render(<SimpleDeviceCard {...defaultProps} device={deviceWithoutProperties} />);
+      
+      expect(screen.getByTestId('device-card-192.168.1.100-0291:1')).toBeInTheDocument();
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('should have correct aria-label for online device', () => {
+      render(<SimpleDeviceCard {...defaultProps} />);
+      
+      const card = screen.getByTestId('device-card-192.168.1.100-0291:1');
+      expect(card).toHaveAttribute('aria-label', 'Single Function Lighting');
+    });
+
+    it('should have correct aria-label for offline device', () => {
+      const offlineDevice = { ...mockDevice, isOffline: true };
+      
+      render(<SimpleDeviceCard {...defaultProps} device={offlineDevice} />);
+      
+      const card = screen.getByTestId('device-card-192.168.1.100-0291:1');
+      expect(card).toHaveAttribute('aria-label', 'Single Function Lighting (オフライン)');
+    });
+
+    it('should have correct aria-label for device with alias', () => {
+      const mockGetDeviceAliases = vi.mocked(deviceIdHelper.getDeviceAliases);
+      mockGetDeviceAliases.mockReturnValue({
+        aliases: ['Living Room Light'],
+        deviceIdentifier: '192.168.1.100 0291:1'
+      });
+
+      render(<SimpleDeviceCard {...defaultProps} />);
+      
+      const card = screen.getByTestId('device-card-192.168.1.100-0291:1');
+      expect(card).toHaveAttribute('aria-label', 'Living Room Light');
+    });
+
+    it('should have correct aria-label for offline device with alias', () => {
+      const mockGetDeviceAliases = vi.mocked(deviceIdHelper.getDeviceAliases);
+      mockGetDeviceAliases.mockReturnValue({
+        aliases: ['Living Room Light'],
+        deviceIdentifier: '192.168.1.100 0291:1'
+      });
+      const offlineDevice = { ...mockDevice, isOffline: true };
+
+      render(<SimpleDeviceCard {...defaultProps} device={offlineDevice} />);
+      
+      const card = screen.getByTestId('device-card-192.168.1.100-0291:1');
+      expect(card).toHaveAttribute('aria-label', 'Living Room Light (オフライン)');
+    });
+  });
+
+  describe('Offline styling', () => {
+    it('should apply offline styling when device is offline', () => {
+      const offlineDevice = { ...mockDevice, isOffline: true };
+      
+      render(<SimpleDeviceCard {...defaultProps} device={offlineDevice} />);
+      
+      const card = screen.getByTestId('device-card-192.168.1.100-0291:1');
+      expect(card).toHaveClass('after:absolute');
+      expect(card).toHaveClass('after:inset-0');
+      expect(card).toHaveClass('after:bg-background/60');
+      expect(card).toHaveClass('after:pointer-events-none');
+      expect(card).toHaveClass('after:rounded-lg');
+    });
+
+    it('should not apply offline styling when device is online', () => {
+      render(<SimpleDeviceCard {...defaultProps} />);
+      
+      const card = screen.getByTestId('device-card-192.168.1.100-0291:1');
+      expect(card).not.toHaveClass('after:absolute');
+    });
+  });
+
+  describe('Draggable functionality', () => {
+    it('should be draggable when isDraggable is true', () => {
+      const onDragStart = vi.fn();
+      const onDragEnd = vi.fn();
+
+      render(
+        <SimpleDeviceCard 
+          {...defaultProps} 
+          isDraggable={true}
+          onDragStart={onDragStart}
+          onDragEnd={onDragEnd}
+        />
+      );
+      
+      const card = screen.getByTestId('device-card-192.168.1.100-0291:1');
+      expect(card).toHaveAttribute('draggable', 'true');
+      expect(screen.getByText('Single Function Lighting')).toBeInTheDocument();
+    });
+
+    it('should not be draggable when isLoading is true', () => {
+      render(
+        <SimpleDeviceCard 
+          {...defaultProps} 
+          isDraggable={true}
+          isLoading={true}
+        />
+      );
+      
+      const card = screen.getByTestId('device-card-192.168.1.100-0291:1');
+      expect(card).toHaveAttribute('draggable', 'false');
+    });
+
+    it('should apply dragging opacity when isDragging is true', () => {
+      render(
+        <SimpleDeviceCard 
+          {...defaultProps} 
+          isDraggable={true}
+          isDragging={true}
+        />
+      );
+      
+      const card = screen.getByTestId('device-card-192.168.1.100-0291:1');
+      expect(card).toHaveClass('opacity-50');
+    });
+
+    it('should call onDragStart with correct parameters', () => {
+      const onDragStart = vi.fn();
+
+      render(
+        <SimpleDeviceCard 
+          {...defaultProps} 
+          isDraggable={true}
+          onDragStart={onDragStart}
+        />
+      );
+      
+      const card = screen.getByTestId('device-card-192.168.1.100-0291:1');
+      fireEvent.dragStart(card);
+      
+      expect(onDragStart).toHaveBeenCalledWith(
+        expect.any(Object),
+        '192.168.1.100 0291:1'
+      );
+    });
+  });
+
+  describe('Action button', () => {
+    it('should render add action button', () => {
+      const onClick = vi.fn();
+
+      render(
+        <SimpleDeviceCard 
+          {...defaultProps} 
+          actionButton={{
+            type: 'add',
+            onClick,
+            title: 'Add device'
+          }}
+        />
+      );
+      
+      const button = screen.getByTestId('add-device-192.168.1.100-0291:1');
+      expect(button).toBeInTheDocument();
+      expect(button).toHaveAttribute('title', 'Add device');
+    });
+
+    it('should render remove action button', () => {
+      const onClick = vi.fn();
+
+      render(
+        <SimpleDeviceCard 
+          {...defaultProps} 
+          actionButton={{
+            type: 'remove',
+            onClick,
+            title: 'Remove device'
+          }}
+        />
+      );
+      
+      const button = screen.getByTestId('remove-device-192.168.1.100-0291:1');
+      expect(button).toBeInTheDocument();
+    });
+
+    it('should render custom action button with custom icon', () => {
+      const onClick = vi.fn();
+      const customIcon = <div data-testid="custom-icon">⚙️</div>;
+
+      render(
+        <SimpleDeviceCard 
+          {...defaultProps} 
+          actionButton={{
+            type: 'custom',
+            onClick,
+            icon: customIcon,
+            title: 'Custom action'
+          }}
+        />
+      );
+      
+      const button = screen.getByTestId('custom-device-192.168.1.100-0291:1');
+      expect(button).toBeInTheDocument();
+      expect(screen.getByTestId('custom-icon')).toBeInTheDocument();
+    });
+
+    it('should call onClick when action button is clicked', async () => {
+      const user = userEvent.setup();
+      const onClick = vi.fn();
+
+      render(
+        <SimpleDeviceCard 
+          {...defaultProps} 
+          actionButton={{
+            type: 'add',
+            onClick
+          }}
+        />
+      );
+      
+      const button = screen.getByTestId('add-device-192.168.1.100-0291:1');
+      await user.click(button);
+      
+      expect(onClick).toHaveBeenCalledOnce();
+    });
+
+    it('should disable action button when disabled prop is true', () => {
+      const onClick = vi.fn();
+
+      render(
+        <SimpleDeviceCard 
+          {...defaultProps} 
+          actionButton={{
+            type: 'add',
+            onClick,
+            disabled: true
+          }}
+        />
+      );
+      
+      const button = screen.getByTestId('add-device-192.168.1.100-0291:1');
+      expect(button).toBeDisabled();
+    });
+
+    it('should disable action button when isLoading is true', () => {
+      const onClick = vi.fn();
+
+      render(
+        <SimpleDeviceCard 
+          {...defaultProps} 
+          isLoading={true}
+          actionButton={{
+            type: 'add',
+            onClick
+          }}
+        />
+      );
+      
+      const button = screen.getByTestId('add-device-192.168.1.100-0291:1');
+      expect(button).toBeDisabled();
+    });
+  });
+
+  describe('Multiple aliases display', () => {
+    it('should show alias count badge when multiple aliases exist', () => {
+      const mockGetDeviceAliases = vi.mocked(deviceIdHelper.getDeviceAliases);
+      mockGetDeviceAliases.mockReturnValue({
+        aliases: ['Alias 1', 'Alias 2', 'Alias 3'],
+        deviceIdentifier: '192.168.1.100 0291:1'
+      });
+
+      render(<SimpleDeviceCard {...defaultProps} />);
+      
+      const badge = screen.getByText('+2');
+      expect(badge).toBeInTheDocument();
+    });
+
+    it('should not show alias count badge when only one alias exists', () => {
+      const mockGetDeviceAliases = vi.mocked(deviceIdHelper.getDeviceAliases);
+      mockGetDeviceAliases.mockReturnValue({
+        aliases: ['Single Alias'],
+        deviceIdentifier: '192.168.1.100 0291:1'
+      });
+
+      render(<SimpleDeviceCard {...defaultProps} />);
+      
+      expect(screen.queryByText('+0')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Compact mode', () => {
+    it('should apply truncate class in compact mode', () => {
+      render(<SimpleDeviceCard {...defaultProps} isCompact={true} />);
+      
+      const container = screen.getByTestId('device-card-192.168.1.100-0291:1');
+      expect(container).toBeInTheDocument();
+    });
+
+    it('should not show secondary device info in compact mode with alias', () => {
+      const mockGetDeviceAliases = vi.mocked(deviceIdHelper.getDeviceAliases);
+      mockGetDeviceAliases.mockReturnValue({
+        aliases: ['Living Room Light'],
+        deviceIdentifier: '192.168.1.100 0291:1'
+      });
+
+      render(<SimpleDeviceCard {...defaultProps} isCompact={true} />);
+      
+      expect(screen.getByText('Living Room Light')).toBeInTheDocument();
+      expect(screen.queryByText('Single Function Lighting')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Installation location display', () => {
+    it('should display installation location when available', () => {
+      const mockFormatPropertyValue = vi.mocked(propertyHelper.formatPropertyValue);
+      mockFormatPropertyValue.mockReturnValue('Living Room');
+
+      render(<SimpleDeviceCard {...defaultProps} />);
+      
+      expect(screen.getByText(/設置場所: Living Room/)).toBeInTheDocument();
+    });
+
+    it('should not display installation location when not available', () => {
+      const deviceWithoutLocation = {
+        ...mockDevice,
+        properties: { '80': { string: 'on' } }
+      };
+
+      render(<SimpleDeviceCard {...defaultProps} device={deviceWithoutLocation} />);
+      
+      expect(screen.queryByText(/設置場所:/)).not.toBeInTheDocument();
+    });
+  });
+});

--- a/web/src/components/SimpleDeviceCard.tsx
+++ b/web/src/components/SimpleDeviceCard.tsx
@@ -46,8 +46,13 @@ export function SimpleDeviceCard({
   className = '',
   isCompact = false,
 }: SimpleDeviceCardProps) {
+  // Null safety checks
+  if (!device || !getDeviceClassCode) {
+    return null;
+  }
+
   const { aliases: deviceAliases } = getDeviceAliases(device, allDevices, aliases);
-  const locationProperty = device.properties['81'];
+  const locationProperty = device.properties?.['81'];
   
   // Get device class code and property descriptor like original DeviceCard does
   const classCode = getDeviceClassCode(device);
@@ -72,6 +77,7 @@ export function SimpleDeviceCard({
       } ${isLoading ? 'cursor-not-allowed opacity-50' : ''} ${
         device.isOffline ? 'after:absolute after:inset-0 after:bg-background/60 after:pointer-events-none after:rounded-lg' : ''
       } ${className}`}
+      aria-label={device.isOffline ? `${deviceAliases[0] || deviceDisplayName} (オフライン)` : deviceAliases[0] || deviceDisplayName}
     >
       <CardContent className="p-3">
         <div className="flex items-start gap-2">

--- a/web/src/components/SimpleDeviceCard.tsx
+++ b/web/src/components/SimpleDeviceCard.tsx
@@ -2,6 +2,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { GripVertical, Plus, Minus } from 'lucide-react';
+import { DeviceIcon } from '@/components/DeviceIcon';
 import { getDeviceAliases } from '@/libs/deviceIdHelper';
 import { formatPropertyValue, getPropertyDescriptor } from '@/libs/propertyHelper';
 import type { Device, DeviceAlias, PropertyDescriptionData } from '@/hooks/types';
@@ -66,9 +67,11 @@ export function SimpleDeviceCard({
       draggable={isDraggable && !isLoading}
       onDragStart={isDraggable ? (e) => onDragStart?.(e, deviceKey) : undefined}
       onDragEnd={isDraggable ? onDragEnd : undefined}
-      className={`transition-opacity overflow-hidden ${
+      className={`transition-opacity overflow-hidden relative ${
         isDragging ? 'opacity-50' : ''
-      } ${isLoading ? 'cursor-not-allowed opacity-50' : ''} ${className}`}
+      } ${isLoading ? 'cursor-not-allowed opacity-50' : ''} ${
+        device.isOffline ? 'after:absolute after:inset-0 after:bg-background/60 after:pointer-events-none after:rounded-lg' : ''
+      } ${className}`}
     >
       <CardContent className="p-3">
         <div className="flex items-start gap-2">
@@ -78,11 +81,14 @@ export function SimpleDeviceCard({
           <div className="flex-1 min-w-0 space-y-2">
             {/* Primary identification */}
             <div className="space-y-1">
-              {deviceAliases.length > 0 ? (
-                <div className={`text-sm font-medium ${isCompact ? 'truncate' : ''}`}>{deviceAliases[0]}</div>
-              ) : (
-                <div className={`text-sm font-medium ${isCompact ? 'truncate' : ''}`}>{deviceDisplayName}</div>
-              )}
+              <div className="flex items-center gap-2">
+                <DeviceIcon device={device} classCode={classCode} />
+                {deviceAliases.length > 0 ? (
+                  <div className={`text-sm font-medium ${isCompact ? 'truncate' : ''}`}>{deviceAliases[0]}</div>
+                ) : (
+                  <div className={`text-sm font-medium ${isCompact ? 'truncate' : ''}`}>{deviceDisplayName}</div>
+                )}
+              </div>
               {deviceAliases.length > 0 && !isCompact ? (
                 <div className={`text-xs text-muted-foreground ${isCompact ? 'truncate' : ''}`}>{deviceDisplayName}</div>
               ) : !deviceAliases.length ? (


### PR DESCRIPTION
## Summary

- Added DeviceIcon component integration to SimpleDeviceCard for consistent visual device identification
- Implemented offline device styling with semi-transparent overlay effect to match main DeviceCard behavior
- Enhanced UI consistency across device display components

## Changes

- Import and integrate `DeviceIcon` component in SimpleDeviceCard
- Add device icon display alongside device name in primary identification section  
- Implement offline device styling using CSS overlay with `after:` pseudo-element
- Maintain responsive layout and existing component functionality

## Test plan

- [x] Go tests pass (`go test ./...`)
- [x] Go build succeeds (`go build`)
- [x] Web UI tests pass (`npm run test`)
- [x] Web UI linting passes (`npm run lint`)
- [x] Web UI type checking passes (`npm run typecheck`)
- [x] Web UI build succeeds (`npm run build`)
- [x] Manual testing: Verify device icons appear in SimpleDeviceCard components
- [ ] Manual testing: Verify offline devices show dimmed overlay effect in SimpleDeviceCard

🤖 Generated with [Claude Code](https://claude.ai/code)