### PR TITLE
fix: improve UpdateProperties concurrency control from IP-level to device-level (IP+EOJ)

### DIFF
--- a/echonet_lite/handler/handler_communication_retry_simple_test.go
+++ b/echonet_lite/handler/handler_communication_retry_simple_test.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"context"
+	"echonet-list/echonet_lite"
 	"fmt"
 	"net"
 	"sync"
@@ -28,50 +29,52 @@ func TestActiveUpdatesTracking(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 
 	ip := net.ParseIP("192.168.1.100")
+	device := IPAndEOJ{IP: ip, EOJ: echonet_lite.MakeEOJ(0x0291, 0x01)}
 
 	t.Run("basic active update tracking", func(t *testing.T) {
 		// 最初はアクティブではない
-		assert.False(t, handler.isUpdateActive(ip, false))
+		assert.False(t, handler.isUpdateActive(device, false))
 
 		// アクティブにマーク
-		handler.markUpdateActive(ip)
+		handler.markUpdateActive(device)
 
 		// アクティブになったことを確認
-		assert.True(t, handler.isUpdateActive(ip, false))
+		assert.True(t, handler.isUpdateActive(device, false))
 
 		// 非アクティブにマーク
-		handler.markUpdateInactive(ip)
+		handler.markUpdateInactive(device)
 
 		// 非アクティブになったことを確認
-		assert.False(t, handler.isUpdateActive(ip, false))
+		assert.False(t, handler.isUpdateActive(device, false))
 	})
 
 	t.Run("force flag bypasses active check", func(t *testing.T) {
 		// アクティブにマーク
-		handler.markUpdateActive(ip)
+		handler.markUpdateActive(device)
 
 		// force=falseの場合はアクティブ
-		assert.True(t, handler.isUpdateActive(ip, false))
+		assert.True(t, handler.isUpdateActive(device, false))
 
 		// force=trueの場合は非アクティブとして扱われる
-		assert.False(t, handler.isUpdateActive(ip, true))
+		assert.False(t, handler.isUpdateActive(device, true))
 
 		// クリーンアップ
-		handler.markUpdateInactive(ip)
+		handler.markUpdateInactive(device)
 	})
 
 	t.Run("old entries are cleaned up automatically", func(t *testing.T) {
 		// アクティブにマーク
-		handler.markUpdateActive(ip)
-		assert.True(t, handler.isUpdateActive(ip, false))
+		handler.markUpdateActive(device)
+		assert.True(t, handler.isUpdateActive(device, false))
 
 		// 古いエントリを手動で設定（テスト用）
 		handler.activeUpdatesMu.Lock()
-		handler.activeUpdates[ip.String()] = time.Now().Add(-MaxUpdateAge - time.Minute)
+		deviceKey := fmt.Sprintf("%s:%04X:%02X", device.IP.String(), uint16(device.EOJ.ClassCode()), device.EOJ.InstanceCode())
+		handler.activeUpdates[deviceKey] = time.Now().Add(-MaxUpdateAge - time.Minute)
 		handler.activeUpdatesMu.Unlock()
 
 		// 古いエントリは自動的にクリーンアップされる
-		assert.False(t, handler.isUpdateActive(ip, false))
+		assert.False(t, handler.isUpdateActive(device, false))
 	})
 
 	t.Run("concurrent access safety", func(t *testing.T) {
@@ -86,11 +89,12 @@ func TestActiveUpdatesTracking(t *testing.T) {
 			go func(id int) {
 				defer wg.Done()
 				testIP := net.ParseIP(fmt.Sprintf("192.168.1.%d", 100+id))
+				testDevice := IPAndEOJ{IP: testIP, EOJ: echonet_lite.MakeEOJ(0x0291, 0x01)}
 
 				for j := 0; j < iterations; j++ {
-					handler.markUpdateActive(testIP)
-					handler.isUpdateActive(testIP, false)
-					handler.markUpdateInactive(testIP)
+					handler.markUpdateActive(testDevice)
+					handler.isUpdateActive(testDevice, false)
+					handler.markUpdateInactive(testDevice)
 				}
 			}(i)
 		}
@@ -100,53 +104,56 @@ func TestActiveUpdatesTracking(t *testing.T) {
 	})
 
 	t.Run("background cleanup works", func(t *testing.T) {
-		// 複数のIPをアクティブにマーク
-		ips := []net.IP{
-			net.ParseIP("192.168.1.101"),
-			net.ParseIP("192.168.1.102"),
-			net.ParseIP("192.168.1.103"),
+		// 複数のデバイスをアクティブにマーク
+		devices := []IPAndEOJ{
+			{IP: net.ParseIP("192.168.1.101"), EOJ: echonet_lite.MakeEOJ(0x0291, 0x01)},
+			{IP: net.ParseIP("192.168.1.102"), EOJ: echonet_lite.MakeEOJ(0x0291, 0x01)},
+			{IP: net.ParseIP("192.168.1.103"), EOJ: echonet_lite.MakeEOJ(0x0291, 0x01)},
 		}
 
-		for _, ip := range ips {
-			handler.markUpdateActive(ip)
+		for _, device := range devices {
+			handler.markUpdateActive(device)
 		}
 
 		// 一部を古いエントリに設定
 		handler.activeUpdatesMu.Lock()
-		handler.activeUpdates[ips[0].String()] = time.Now().Add(-MaxUpdateAge - time.Minute)
-		handler.activeUpdates[ips[1].String()] = time.Now().Add(-MaxUpdateAge - time.Minute)
+		deviceKey0 := fmt.Sprintf("%s:%04X:%02X", devices[0].IP.String(), uint16(devices[0].EOJ.ClassCode()), devices[0].EOJ.InstanceCode())
+		deviceKey1 := fmt.Sprintf("%s:%04X:%02X", devices[1].IP.String(), uint16(devices[1].EOJ.ClassCode()), devices[1].EOJ.InstanceCode())
+		handler.activeUpdates[deviceKey0] = time.Now().Add(-MaxUpdateAge - time.Minute)
+		handler.activeUpdates[deviceKey1] = time.Now().Add(-MaxUpdateAge - time.Minute)
 		handler.activeUpdatesMu.Unlock()
 
 		// バックグラウンドクリーンアップを手動実行
 		handler.cleanupStaleActiveUpdates()
 
 		// 古いエントリが削除され、新しいエントリは残っていることを確認
-		assert.False(t, handler.isUpdateActive(ips[0], false))
-		assert.False(t, handler.isUpdateActive(ips[1], false))
-		assert.True(t, handler.isUpdateActive(ips[2], false))
+		assert.False(t, handler.isUpdateActive(devices[0], false))
+		assert.False(t, handler.isUpdateActive(devices[1], false))
+		assert.True(t, handler.isUpdateActive(devices[2], false))
 
 		// クリーンアップ
-		handler.markUpdateInactive(ips[2])
+		handler.markUpdateInactive(devices[2])
 	})
 
 	t.Run("double-checked locking works correctly", func(t *testing.T) {
-		testIP := net.ParseIP("192.168.1.200")
+		testDevice := IPAndEOJ{IP: net.ParseIP("192.168.1.200"), EOJ: echonet_lite.MakeEOJ(0x0291, 0x01)}
 
 		// アクティブにマーク
-		handler.markUpdateActive(testIP)
-		assert.True(t, handler.isUpdateActive(testIP, false))
+		handler.markUpdateActive(testDevice)
+		assert.True(t, handler.isUpdateActive(testDevice, false))
 
 		// 古いエントリを設定
 		handler.activeUpdatesMu.Lock()
-		handler.activeUpdates[testIP.String()] = time.Now().Add(-MaxUpdateAge - time.Minute)
+		deviceKey := fmt.Sprintf("%s:%04X:%02X", testDevice.IP.String(), uint16(testDevice.EOJ.ClassCode()), testDevice.EOJ.InstanceCode())
+		handler.activeUpdates[deviceKey] = time.Now().Add(-MaxUpdateAge - time.Minute)
 		handler.activeUpdatesMu.Unlock()
 
 		// isUpdateActiveを呼び出すと、double-checked lockingによって古いエントリが削除される
-		assert.False(t, handler.isUpdateActive(testIP, false))
+		assert.False(t, handler.isUpdateActive(testDevice, false))
 
 		// エントリが削除されていることを確認
 		handler.activeUpdatesMu.RLock()
-		_, exists := handler.activeUpdates[testIP.String()]
+		_, exists := handler.activeUpdates[deviceKey]
 		handler.activeUpdatesMu.RUnlock()
 		assert.False(t, exists)
 	})


### PR DESCRIPTION
## Summary

This PR fixes a concurrency issue in the ECHONET Lite controller where UpdateProperties was using IP-level locking that was too coarse-grained. ECHONET Lite devices have multiple objects (NodeProfile + device objects) on the same IP address, and the previous IP-based locking caused unnecessary blocking between different objects.

## Changes Made

- **Enhanced concurrency control**: Changed from IP-based to device-level (IP+EOJ) locking
- **Updated activeUpdates map**: Key format changed from IP string to `"IP:ClassCode:InstanceCode"`
- **Refactored locking functions**: `isUpdateActive`, `markUpdateActive`, `markUpdateInactive` now work with `IPAndEOJ` instead of `net.IP`
- **Improved broadcast group handling**: Enhanced to check all devices individually for active status
- **Comprehensive test updates**: Updated test files to properly test device-level concurrency

## Technical Details

### Key Format Change
```go
// Before: IP-based key
ipStr := ip.String()

// After: Device-based key (IP+EOJ)
deviceKey := fmt.Sprintf("%s:%04X:%02X", device.IP.String(), uint16(device.EOJ.ClassCode()), device.EOJ.InstanceCode())
```

### Function Signature Updates
```go
// Before
func (h *CommunicationHandler) isUpdateActive(ip net.IP, force bool) bool

// After  
func (h *CommunicationHandler) isUpdateActive(device IPAndEOJ, force bool) bool
```

## Benefits

- **Improved concurrency**: Different ECHONET objects on the same IP can now update simultaneously
- **Reduced blocking**: NodeProfile updates no longer block device object updates
- **Better resource utilization**: More parallel processing of device updates
- **Maintained thread safety**: All existing synchronization guarantees preserved

## Testing

✅ **Pre-commit validation completed:**
- Go formatting: `go fmt ./...` - passed
- Go vet analysis: `go vet ./...` - passed  
- Go tests: `go test ./...` - **all tests passed**
- Go build: `go build` - successful
- Web UI lint: `npm run lint` - passed
- Web UI typecheck: `npm run typecheck` - passed
- Web UI tests: `npm run test` - **462/462 tests passed**
- Web UI build: `npm run build` - successful

## Test Coverage

- **Basic functionality**: Active/inactive marking and checking
- **Force flag behavior**: Ensuring force=true bypasses active checks  
- **Automatic cleanup**: Testing that old entries are cleaned up
- **Concurrency safety**: Multiple goroutines accessing the same functions
- **Background cleanup**: Testing the cleanup mechanism
- **Double-checked locking**: Verifying race condition prevention

## Addresses Issue

This resolves the concurrency bottleneck identified in PR #161 where IP-level locking was preventing efficient parallel updates to different ECHONET Lite objects on the same physical device.

🤖 Generated with [Claude Code](https://claude.ai/code)