### PR TITLE
feat: SimpleDeviceCard compact modeでツールチップ表示

### DIFF
--- a/web/src/components/SimpleDeviceCard.tsx
+++ b/web/src/components/SimpleDeviceCard.tsx
@@ -90,9 +90,19 @@ export function SimpleDeviceCard({
               <div className="flex items-center gap-2">
                 <DeviceIcon device={device} classCode={classCode} />
                 {deviceAliases.length > 0 ? (
-                  <div className={`text-sm font-medium ${isCompact ? 'truncate' : ''}`}>{deviceAliases[0]}</div>
+                  <div 
+                    className={`text-sm font-medium ${isCompact ? 'truncate' : ''}`}
+                    title={isCompact ? deviceAliases[0] : undefined}
+                  >
+                    {deviceAliases[0]}
+                  </div>
                 ) : (
-                  <div className={`text-sm font-medium ${isCompact ? 'truncate' : ''}`}>{deviceDisplayName}</div>
+                  <div 
+                    className={`text-sm font-medium ${isCompact ? 'truncate' : ''}`}
+                    title={isCompact ? deviceDisplayName : undefined}
+                  >
+                    {deviceDisplayName}
+                  </div>
                 )}
               </div>
               {deviceAliases.length > 0 && !isCompact ? (
@@ -102,7 +112,11 @@ export function SimpleDeviceCard({
               ) : null}
               {/* Installation location display */}
               {locationDisplay && (
-                <div className={`text-xs text-muted-foreground ${isCompact ? 'truncate' : ''}`} aria-label="Installation location">
+                <div 
+                  className={`text-xs text-muted-foreground ${isCompact ? 'truncate' : ''}`} 
+                  aria-label="Installation location"
+                  title={isCompact ? `設置場所: ${locationDisplay}` : undefined}
+                >
                   設置場所: {locationDisplay}
                 </div>
               )}


### PR DESCRIPTION
## Summary
- SimpleDeviceCardコンポーネントのcompact modeで省略されるテキストにツールチップを追加
- デバイス名と設置場所がtruncateされる場合、マウスホバーで完全なテキストを表示
- HTML標準のtitle属性を使用した軽量な実装

## Changes
- デバイス名（エイリアスまたは通常名）にtitle属性を追加
- 設置場所表示にtitle属性を追加  
- compact mode時のみツールチップを表示（通常モードではundefined）

## Test plan
- [x] TypeScript型チェック成功
- [x] ESLintチェック成功
- [x] 全テストケース成功（462 tests passed）
- [x] ビルド成功
- [x] compact modeでデバイス名にホバー時ツールチップ表示確認
- [x] compact modeで設置場所にホバー時ツールチップ表示確認
- [ ] 通常モードでツールチップが表示されないこと確認

🤖 Generated with Claude Code