### PR TITLE
refactor: simplify device timeout notification handling

### DIFF
--- a/echonet_lite/handler/Session_offline_test.go
+++ b/echonet_lite/handler/Session_offline_test.go
@@ -60,7 +60,7 @@ func TestSession_OfflineLogSuppression(t *testing.T) {
 	}
 
 	// notifyDeviceTimeoutは常にErrMaxRetriesReachedエラーを返す
-	err = session.notifyDeviceTimeout(device)
+	err = session.notifyDeviceTimeout(device, 0)
 	if err == nil {
 		t.Error("Expected error from notifyDeviceTimeout")
 	}
@@ -90,7 +90,7 @@ func TestSession_OfflineLogSuppressionWithNilFunc(t *testing.T) {
 	defer session.Close()
 
 	// notifyDeviceTimeoutを直接呼び出してテスト
-	err = session.notifyDeviceTimeout(device)
+	err = session.notifyDeviceTimeout(device, 0)
 	if err == nil {
 		t.Error("Expected error from notifyDeviceTimeout")
 	}
@@ -147,7 +147,7 @@ func TestSession_OnlineDeviceLogging(t *testing.T) {
 	}
 
 	// notifyDeviceTimeoutを直接呼び出してテスト
-	err = session.notifyDeviceTimeout(device)
+	err = session.notifyDeviceTimeout(device, 0)
 	if err == nil {
 		t.Error("Expected error from notifyDeviceTimeout")
 	}


### PR DESCRIPTION
## Summary

Refactors the device timeout notification system in the ECHONET Lite handler to reduce code duplication and improve maintainability.

### Changes Made

- **Function consolidation**: Renamed `notifyDeviceTimeoutWithContext` to `notifyDeviceTimeout` and removed the redundant simple version
- **Parameter simplification**: Removed `retryInterval` parameter since all callers were passing `s.RetryInterval`
- **Logging cleanup**: Removed duplicate logging from caller sites - timeout logging is now centralized in `notifyDeviceTimeout`  
- **Code simplification**: Removed redundant `IsOfflineFunc` checks from retry logic for cleaner control flow
- **Test updates**: Updated all test cases to match the new function signature

### Benefits

- Reduced code duplication and complexity
- Centralized timeout logging for consistency
- Simplified function signatures
- Cleaner control flow in retry logic

### Test Results

✅ All Go tests pass (`go test ./...`)
✅ All Web UI tests pass (`npm run test`)
✅ Code formatting and linting checks pass
✅ Build successful

🤖 Generated with [Claude Code](https://claude.ai/code)