### PR TITLE
fix: prevent false positive bundle stale detection on tab switch

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -112,16 +112,27 @@
         function checkOnVisibilityChange() {
           try {
             if (!document.hidden) {
-              const mainScript = document.querySelector(`script[src*="${SCRIPT_PATTERN}"]`);
-              if (mainScript && !window.React) {
-                const reloadAttempted = sessionStorage.getItem(RELOAD_FLAG_KEY);
-                if (!reloadAttempted) {
-                  sessionStorage.setItem(RELOAD_FLAG_KEY, 'true');
-                  location.reload();
-                } else {
-                  showErrorOverlay();
+              // Give a small delay to allow React to render after tab becomes visible
+              setTimeout(() => {
+                try {
+                  // Check if React app root is populated (more reliable than window.React)
+                  const root = document.getElementById('root');
+                  const hasRenderedContent = root && root.children.length > 0;
+                  
+                  // Only trigger reload if root is empty (indicating failed app load)
+                  if (!hasRenderedContent) {
+                    const reloadAttempted = sessionStorage.getItem(RELOAD_FLAG_KEY);
+                    if (!reloadAttempted) {
+                      sessionStorage.setItem(RELOAD_FLAG_KEY, 'true');
+                      location.reload();
+                    } else {
+                      showErrorOverlay();
+                    }
+                  }
+                } catch (error) {
+                  console.warn('Bundle stale detection error:', error);
                 }
-              }
+              }, 500); // 500ms delay to allow React to rehydrate
             }
           } catch (error) {
             console.warn('Bundle stale detection error:', error);


### PR DESCRIPTION
## Summary
- バンドル更新検出機能の誤検出を修正
- タブ切り替え時に不適切にリロードプロンプトが表示される問題を解決

## Problem
PR #172 で実装したバンドル更新検出機能において、`window.React` の存在チェックによる誤検出が発生していました：
- 正常なReactアプリケーションでも `window.React` が存在しない場合がある
- タブ切り替えのたびに「アプリケーションの更新が必要です」が表示される
- サーバー更新していない状況でも誤動作

## Changes
- **検出ロジック改善**: `window.React` チェックを `#root` 要素の内容確認に変更
- **遅延処理追加**: 500msの遅延でReactの再ハイドレーション完了を待機
- **正確な判定**: `root.children.length > 0` でレンダリング済みかを確認

### Technical Details
**Before:**
```javascript
if (mainScript && \!window.React) {
  // 誤検出の原因
}
```

**After:**
```javascript
setTimeout(() => {
  const root = document.getElementById('root');
  const hasRenderedContent = root && root.children.length > 0;
  if (\!hasRenderedContent) {
    // 実際にレンダリングが失敗した場合のみ
  }
}, 500);
```

## Test Results
✅ Go: fmt, vet, test, build - 全て成功  
✅ Web UI: lint, typecheck, test (462 tests passed), build - 全て成功

## Verification
- タブ切り替え時に誤検出が発生しないことを確認
- 実際のバンドルファイル不在時の検出は正常動作

🤖 Generated with [Claude Code](https://claude.ai/code)