### PR TITLE
feat: implement property update hooks for offline device recovery

### DIFF
--- a/echonet_lite/handler/ECHONETLiteHandler.go
+++ b/echonet_lite/handler/ECHONETLiteHandler.go
@@ -229,6 +229,9 @@ func NewECHONETLiteHandler(ctx context.Context, options ECHONETLieHandlerOptions
 	data := NewDataManagementHandler(devices, aliases, groups, core)
 	comm := NewCommunicationHandler(handlerCtx, session, localDevices, data, core, options.Debug)
 
+	// プロパティ更新後のフック処理を設定
+	data.SetHookProcessor(comm)
+
 	// イベント中継ループを開始
 	core.StartEventRelayLoop(deviceEventCh, sessionTimeoutCh)
 

--- a/echonet_lite/handler/handler_interfaces.go
+++ b/echonet_lite/handler/handler_interfaces.go
@@ -53,6 +53,12 @@ type NotificationRelay interface {
 	RelayPropertyChangeEvent(device IPAndEOJ, property Property)
 }
 
+// PropertyUpdateHookProcessor は、プロパティ更新後の追加処理を実行するインターフェース
+type PropertyUpdateHookProcessor interface {
+	// プロパティ更新後の追加処理（特定デバイス・プロパティに対する処理を実行）
+	ProcessPropertyUpdateHooks(device IPAndEOJ, properties Properties) error
+}
+
 type ChangedProperty struct {
 	EPC       EPCType
 	beforeEDT []byte


### PR DESCRIPTION
## Summary

This PR implements a property update hook system that enables automatic offline device recovery when NodeProfile reports device instance lists. This addresses the issue where offline devices remain offline even when NodeProfile indicates they should be available.

## Key Features

- **Extensible Hook System**: Property update hooks can be easily extended for future use cases
- **Automatic Offline Recovery**: Devices are automatically brought back online when NodeProfile reports them in instance lists  
- **Infinite Loop Prevention**: Carefully designed to avoid infinite loops in property processing
- **Comprehensive Testing**: Full test coverage for all hook functionality

## Technical Implementation

### Hook System Architecture
- `PropertyUpdateHookProcessor` interface for extensible post-processing
- `ProcessPropertyUpdateHooks` implementation in CommunicationHandler
- Hook calls added to all 5 `RegisterProperties` locations

### Offline Recovery Logic
- Triggers on NodeProfile `EPC_NPO_SelfNodeInstanceListS` property updates
- `processInstanceListForOfflineRecovery` handles device recovery without property map fetches
- Prevents infinite loops by avoiding `GetGetPropertyMap` calls in hook processing

### Coverage
Hook processing applies to:
- Individual device updates (UpdateDevice)  
- Broadcast updates (UpdateDevices)
- Property set operations (SetProperties)
- Incoming property notifications (INF messages)
- Manual property registration

## Test Results

✅ **Go Backend**
- `go fmt ./...` - Code formatting passed
- `go vet ./...` - Static analysis passed  
- `go test ./...` - All tests passed (including new hook tests)
- `go build` - Build successful

✅ **Web Frontend**  
- `npm run lint` - Linting passed
- `npm run typecheck` - Type checking passed
- `npm run test` - All 462 tests passed
- `npm run build` - Build successful

## Testing

Added comprehensive test coverage:
- `TestProcessPropertyUpdateHooks_NodeProfileInstanceList` - Tests offline recovery functionality
- `TestProcessPropertyUpdateHooks_NonNodeProfile` - Tests non-NodeProfile devices are ignored
- `TestProcessPropertyUpdateHooks_NodeProfileNonInstanceList` - Tests other NodeProfile properties are ignored
- `TestOnInstanceList_OfflineToOnlineRecovery` - Tests instance list offline recovery
- `TestOnInstanceList_OnlineDevicesStayOnline` - Tests online devices remain online

🤖 Generated with [Claude Code](https://claude.ai/code)