### PR TITLE
feat: add server startup time and Web UI build date to NotificationBell

### DIFF
--- a/docs/websocket_client_protocol.md
+++ b/docs/websocket_client_protocol.md
@@ -150,7 +150,7 @@ wss://hostname:port/ws     // SSL/TLS暗号化接続
 
 ### initial_state
 
-接続確立時に現在のデバイス状態とエイリアスを通知します。
+接続確立時に現在のデバイス状態とエイリアス、およびサーバーの起動時刻を通知します。
 
 ```json
 {
@@ -197,7 +197,8 @@ wss://hostname:port/ws     // SSL/TLS暗号化接続
     "groups": {
       "@living_room": ["013001:00000B:ABCDEF0123456789ABCDEF012345", "029001:000005:FEDCBA9876543210FEDCBA987654"], // 例
       "@bedroom": ["013001:000008:FEDCBA9876543210ABCDEF012345"] // 例
-    }
+    },
+    "serverStartupTime": "2023-04-01T12:00:00Z" // サーバーの起動時刻（ISO 8601形式）
   }
 }
 ```

--- a/integration/helpers/test_server.go
+++ b/integration/helpers/test_server.go
@@ -4,6 +4,7 @@ package helpers
 
 import (
 	"context"
+	"echonet-list/client"
 	"echonet-list/config"
 	"echonet-list/server"
 	"fmt"
@@ -103,7 +104,8 @@ func (ts *TestServer) Start() error {
 
 	// WebSocketサーバーを作成
 	httpAddr := fmt.Sprintf("%s:%d", ts.Config.HTTPServer.Host, ts.Config.HTTPServer.Port)
-	wsServer, err := server.NewWebSocketServer(ts.ctx, httpAddr, s.GetHandler(), s.GetHandler())
+	serverStartupTime := time.Now().UTC() // テスト用のサーバー起動時刻
+	wsServer, err := server.NewWebSocketServer(ts.ctx, httpAddr, client.NewECHONETListClientProxy(s.GetHandler()), s.GetHandler(), serverStartupTime)
 	if err != nil {
 		return fmt.Errorf("WebSocketサーバーの作成に失敗: %v", err)
 	}

--- a/main.go
+++ b/main.go
@@ -23,6 +23,9 @@ const (
 )
 
 func main() {
+	// サーバーの起動時刻を記録（UTC）
+	serverStartupTime := time.Now().UTC()
+
 	// コマンドライン引数のヘルプメッセージをカスタマイズ
 	flag.Usage = func() {
 		_, _ = fmt.Fprintf(os.Stderr, "使用方法: %s [オプション]\n\nオプション:\n", os.Args[0])
@@ -133,7 +136,7 @@ func main() {
 		httpAddr := fmt.Sprintf("%s:%d", cfg.HTTPServer.Host, cfg.HTTPServer.Port)
 
 		// WebSocketサーバーの作成と起動
-		wsServer, err := server.NewWebSocketServer(ctx, httpAddr, client.NewECHONETListClientProxy(s.GetHandler()), s.GetHandler())
+		wsServer, err := server.NewWebSocketServer(ctx, httpAddr, client.NewECHONETListClientProxy(s.GetHandler()), s.GetHandler(), serverStartupTime)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "WebSocketサーバーの作成に失敗しました: %v\n", err)
 			os.Exit(1)

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -111,9 +111,10 @@ type Error struct {
 
 // InitialStatePayload is the payload for the initial_state message
 type InitialStatePayload struct {
-	Devices map[string]Device             `json:"devices"`
-	Aliases map[string]handler.IDString   `json:"aliases"`
-	Groups  map[string][]handler.IDString `json:"groups"`
+	Devices           map[string]Device             `json:"devices"`
+	Aliases           map[string]handler.IDString   `json:"aliases"`
+	Groups            map[string][]handler.IDString `json:"groups"`
+	ServerStartupTime time.Time                     `json:"serverStartupTime"`
 }
 
 // DeviceAddedPayload is the payload for the device_added message

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -341,6 +341,7 @@ function App() {
               onMarkAllAsRead={logManager.markAllAsRead}
               onClearAll={logManager.clearAllLogs}
               connectedAt={echonet.connectedAt}
+              serverStartupTime={echonet.serverStartupTime}
               onDiscoverDevices={echonet.discoverDevices}
             />
           </div>

--- a/web/src/components/NotificationBell.test.tsx
+++ b/web/src/components/NotificationBell.test.tsx
@@ -28,7 +28,8 @@ describe('NotificationBell', () => {
     unreadCount: 1,
     onMarkAllAsRead: vi.fn(),
     onClearAll: vi.fn(),
-    connectedAt: new Date('2023-04-01T12:00:00Z')
+    connectedAt: new Date('2023-04-01T12:00:00Z'),
+    serverStartupTime: new Date('2023-04-01T11:00:00Z')
   };
 
   it('renders bell icon with unread count badge', () => {

--- a/web/src/components/NotificationBell.tsx
+++ b/web/src/components/NotificationBell.tsx
@@ -11,6 +11,7 @@ interface NotificationBellProps {
   onMarkAllAsRead: () => void;
   onClearAll: () => void;
   connectedAt: Date | null;
+  serverStartupTime: Date | null;
   onDiscoverDevices?: () => Promise<unknown>;
 }
 
@@ -20,6 +21,7 @@ export function NotificationBell({
   onMarkAllAsRead, 
   onClearAll,
   connectedAt,
+  serverStartupTime,
   onDiscoverDevices
 }: NotificationBellProps) {
   const [isOpen, setIsOpen] = useState(false);
@@ -131,11 +133,22 @@ export function NotificationBell({
                 </Button>
               </div>
             </div>
-            {connectedAt && (
+            {/* Timestamp information */}
+            <div className="space-y-1">
+              {serverStartupTime && (
+                <div className="text-xs text-gray-500 dark:text-gray-400">
+                  Server started: {serverStartupTime.toLocaleString()}
+                </div>
+              )}
               <div className="text-xs text-gray-500 dark:text-gray-400">
-                Connected at: {connectedAt.toLocaleString()}
+                Web UI built: {new Date(import.meta.env.BUILD_DATE).toLocaleString()}
               </div>
-            )}
+              {connectedAt && (
+                <div className="text-xs text-gray-500 dark:text-gray-400">
+                  Connected at: {connectedAt.toLocaleString()}
+                </div>
+              )}
+            </div>
           </div>
 
           {/* Content */}

--- a/web/src/components/NotificationBell.tsx
+++ b/web/src/components/NotificationBell.tsx
@@ -5,7 +5,7 @@ import { formatValue } from '../libs/formatValue';
 import { Button } from './ui/button';
 import type { LogEntry } from '../hooks/useLogNotifications';
 
-interface NotificationBellProps {
+export interface NotificationBellProps {
   logs: LogEntry[];
   unreadCount: number;
   onMarkAllAsRead: () => void;
@@ -136,15 +136,15 @@ export function NotificationBell({
             {/* Timestamp information */}
             <div className="space-y-1">
               {serverStartupTime && (
-                <div className="text-xs text-gray-500 dark:text-gray-400">
+                <div className="text-xs text-gray-500 dark:text-gray-400" data-testid="server-startup-time">
                   Server started: {serverStartupTime.toLocaleString()}
                 </div>
               )}
-              <div className="text-xs text-gray-500 dark:text-gray-400">
+              <div className="text-xs text-gray-500 dark:text-gray-400" data-testid="build-time">
                 Web UI built: {new Date(import.meta.env.BUILD_DATE).toLocaleString()}
               </div>
               {connectedAt && (
-                <div className="text-xs text-gray-500 dark:text-gray-400">
+                <div className="text-xs text-gray-500 dark:text-gray-400" data-testid="connection-time">
                   Connected at: {connectedAt.toLocaleString()}
                 </div>
               )}

--- a/web/src/hooks/types.ts
+++ b/web/src/hooks/types.ts
@@ -31,6 +31,7 @@ export type InitialState = {
     devices: Record<string, Device>;
     aliases: DeviceAlias;
     groups: DeviceGroup;
+    serverStartupTime: string; // ISO 8601 format
   };
 };
 
@@ -240,4 +241,5 @@ export type ECHONETState = {
   connectionState: ConnectionState;
   propertyDescriptions: Record<string, PropertyDescriptionData>; // classCode -> PropertyDescriptionData
   initialStateReceived: boolean;
+  serverStartupTime: Date | null; // Server startup timestamp
 };

--- a/web/src/hooks/useECHONET.test.ts
+++ b/web/src/hooks/useECHONET.test.ts
@@ -81,6 +81,7 @@ describe('useECHONET', () => {
         devices: { '192.168.1.10 0130:1': testDevice },
         aliases: { living_ac: '013001:00000B:ABCDEF0123456789ABCDEF012345' },
         groups: { '@living_room': ['013001:00000B:ABCDEF0123456789ABCDEF012345'] },
+        serverStartupTime: '2023-04-01T11:00:00Z',
       },
     };
 
@@ -172,6 +173,7 @@ describe('useECHONET', () => {
         devices: { '192.168.1.10 0130:1': testDevice },
         aliases: {},
         groups: {},
+        serverStartupTime: '2023-04-01T11:00:00Z',
       },
     };
 
@@ -288,6 +290,7 @@ describe('useECHONET', () => {
         devices: { '192.168.1.10 0130:1': testDevice },
         aliases: {},
         groups: {},
+        serverStartupTime: '2023-04-01T11:00:00Z',
       },
     };
 
@@ -336,6 +339,7 @@ describe('useECHONET', () => {
         devices: { '192.168.1.10 0130:1': testDevice },
         aliases: {},
         groups: {},
+        serverStartupTime: '2023-04-01T11:00:00Z',
       },
     };
     
@@ -383,6 +387,7 @@ describe('useECHONET', () => {
         devices: { '192.168.1.10 0130:1': testDevice },
         aliases: {},
         groups: {},
+        serverStartupTime: '2023-04-01T11:00:00Z',
       },
     };
     

--- a/web/src/hooks/useECHONET.ts
+++ b/web/src/hooks/useECHONET.ts
@@ -13,7 +13,7 @@ import type {
 } from './types';
 
 type ECHONETAction =
-  | { type: 'SET_INITIAL_STATE'; payload: { devices: Record<string, Device>; aliases: DeviceAlias; groups: DeviceGroup } }
+  | { type: 'SET_INITIAL_STATE'; payload: { devices: Record<string, Device>; aliases: DeviceAlias; groups: DeviceGroup; serverStartupTime?: string } }
   | { type: 'ADD_DEVICE'; payload: { device: Device } }
   | { type: 'MARK_DEVICE_OFFLINE'; payload: { ip: string; eoj: string } }
   | { type: 'MARK_DEVICE_ONLINE'; payload: { ip: string; eoj: string } }
@@ -32,6 +32,7 @@ function echonetReducer(state: ECHONETState, action: ECHONETAction): ECHONETStat
         devices: action.payload.devices,
         aliases: action.payload.aliases,
         groups: action.payload.groups,
+        serverStartupTime: action.payload.serverStartupTime ? new Date(action.payload.serverStartupTime) : null,
         initialStateReceived: true,
       };
 
@@ -175,6 +176,7 @@ const initialState: ECHONETState = {
   connectionState: 'disconnected',
   propertyDescriptions: {},
   initialStateReceived: false,
+  serverStartupTime: null,
 };
 
 export type ECHONETHook = {
@@ -186,6 +188,7 @@ export type ECHONETHook = {
   propertyDescriptions: Record<string, PropertyDescriptionData>;
   initialStateReceived: boolean;
   connectedAt: Date | null;
+  serverStartupTime: Date | null;
 
   // Device operations
   listDevices: (targets: string[]) => Promise<unknown>;
@@ -243,6 +246,7 @@ export function useECHONET(
             devices: message.payload.devices,
             aliases: message.payload.aliases,
             groups: message.payload.groups,
+            serverStartupTime: message.payload.serverStartupTime,
           },
         });
         break;
@@ -565,6 +569,7 @@ export function useECHONET(
     propertyDescriptions: state.propertyDescriptions,
     initialStateReceived: state.initialStateReceived,
     connectedAt: connection.connectedAt,
+    serverStartupTime: state.serverStartupTime,
 
     // Device operations
     listDevices,

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -20,5 +20,8 @@ export default defineConfig({
       key: '../certs/localhost+2-key.pem',
       cert: '../certs/localhost+2.pem'
     }
-  }
+  },
+  define: {
+    'import.meta.env.BUILD_DATE': JSON.stringify(new Date().toISOString()),
+  },
 })


### PR DESCRIPTION
## Summary

Adds timestamp information to the NotificationBell component to help users verify they're running the latest server and Web UI versions.

### Changes Made

**Server-side enhancements:**
- Added server startup time tracking in `main.go` using UTC timestamps
- Extended WebSocket `initial_state` protocol to include `serverStartupTime` field
- Updated `InitialStatePayload` structure in `protocol/protocol.go`
- Modified WebSocketServer to store and transmit server startup time

**Web UI enhancements:**
- Added Vite build date injection using `define` with build-time ISO string generation
- Updated NotificationBell component to display three timestamps:
  - **Server started**: From WebSocket initial_state (UTC → user's local timezone)
  - **Web UI built**: From Vite build-time define (UTC → user's local timezone)
  - **Connected at**: Existing connection timestamp
- Enhanced TypeScript types in `types.ts` to include server startup time
- Updated `useECHONET` hook to handle and expose server startup time

**Documentation & Testing:**
- Updated WebSocket protocol documentation to include new `serverStartupTime` field
- Fixed all test files to include the new field in mock data
- All tests pass: 462 Web UI tests ✅, Go build/test ✅

### Benefits

Users can now quickly verify:
1. **Server freshness**: When the server was last restarted (useful for config changes)
2. **Web UI version**: When the current Web UI was built (confirms latest code)
3. **Connection status**: When they connected to the server

All timestamps are displayed in the user's local timezone for consistency.

### Technical Details

- **Timezone handling**: Server stores UTC time, WebSocket sends ISO 8601, Web UI displays in local timezone
- **Backward compatibility**: Maintains compatibility with existing WebSocket clients
- **No breaking changes**: All changes are additive and optional

## Test plan

- [x] Go tests pass (`go test ./...`)
- [x] Web UI tests pass (`npm run test`) 
- [x] TypeScript compilation succeeds (`npm run typecheck`)
- [x] Linting passes (`npm run lint`)
- [x] Production build works (`npm run build`)
- [x] Server builds successfully (`go build`)

🤖 Generated with [Claude Code](https://claude.ai/code)