### PR TITLE
feat(web): improve tab indicator accessibility for grayscale mode

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -385,7 +385,9 @@ function App() {
                         <div className="flex items-center gap-1">
                           <div 
                             className={`w-2 h-2 rounded-full ${
-                              hasOperationalDevice ? 'bg-green-500' : 'bg-gray-400'
+                              hasOperationalDevice 
+                                ? 'bg-green-500' 
+                                : 'border-2 border-gray-400 bg-transparent'
                             }`}
                             title={`Power Status: ${hasOperationalDevice ? 'At least one device is ON' : 'All devices are OFF or no devices'}`}
                           />


### PR DESCRIPTION
## Summary
- タブインジケータのOFF状態を塗りつぶしから枠線のみの表示に変更
- グレイスケールモードでもON（緑塗りつぶし）とOFF（枠線のみ）を視覚的に区別可能
- 色覚に依存しないアクセシビリティ改善

## Changes
- `web/src/App.tsx`: タブインジケータのOFF状態スタイルを `bg-gray-400` から `border-2 border-gray-400 bg-transparent` に変更

## Test Plan
- [x] Web UI lint チェック完了
- [x] Web UI 型チェック完了  
- [x] Web UI テスト実行完了（468 tests passed）
- [x] Web UI ビルド完了
- [x] Go テスト・ビルド完了

🤖 Generated with [Claude Code](https://claude.ai/code)