### PR TITLE
fix: separate signed/unsigned aliases for HomeAirConditioner temperature sensors

### DIFF
--- a/echonet_lite/prop_HomeAirConditioner.go
+++ b/echonet_lite/prop_HomeAirConditioner.go
@@ -18,12 +18,28 @@ const (
 func (r PropertyRegistry) HomeAirConditioner() PropertyTable {
 	TemperatureSettingDesc := NumberDesc{Min: 0, Max: 50, Unit: "℃"}
 	MeasuredTemperatureDesc := NumberDesc{Min: -127, Max: 125, Unit: "℃"}
-	ExtraValueAlias := map[string][]byte{
+
+	// 計測温度用のエイリアス（符号付き8bit）
+	MeasuredTemperatureExtraValueAlias := map[string][]byte{
+		"N/A":       {0x7E},
+		"overflow":  {0x7F},
+		"underflow": {0x80},
+	}
+	MeasuredTemperatureExtraValueAliasTranslations := map[string]map[string]string{
+		"ja": {
+			"N/A":       "N/A",
+			"overflow":  "オーバーフロー",
+			"underflow": "アンダーフロー",
+		},
+	}
+
+	// 設定温度・湿度用のエイリアス（符号なし8bit）
+	UnsignedExtraValueAlias := map[string][]byte{
 		"unknown":   {0xFD},
 		"underflow": {0xFE},
 		"overflow":  {0xFF},
 	}
-	ExtraValueAliasTranslations := map[string]map[string]string{
+	UnsignedExtraValueAliasTranslations := map[string]map[string]string{
 		"ja": {
 			"unknown":   "不明",
 			"underflow": "アンダーフロー",
@@ -112,8 +128,8 @@ func (r PropertyRegistry) HomeAirConditioner() PropertyTable {
 				NameTranslations: map[string]string{
 					"ja": "温度設定値",
 				},
-				Aliases:           ExtraValueAlias,
-				AliasTranslations: ExtraValueAliasTranslations,
+				Aliases:           UnsignedExtraValueAlias,
+				AliasTranslations: UnsignedExtraValueAliasTranslations,
 				Decoder:           TemperatureSettingDesc,
 			},
 			EPC_HAC_RelativeHumiditySetting: {
@@ -121,8 +137,8 @@ func (r PropertyRegistry) HomeAirConditioner() PropertyTable {
 				NameTranslations: map[string]string{
 					"ja": "除湿モード時相対湿度設定値",
 				},
-				Aliases:           ExtraValueAlias,
-				AliasTranslations: ExtraValueAliasTranslations,
+				Aliases:           UnsignedExtraValueAlias,
+				AliasTranslations: UnsignedExtraValueAliasTranslations,
 				Decoder:           HumidityDesc,
 			},
 			EPC_HAC_CurrentRoomHumidity: {
@@ -130,8 +146,8 @@ func (r PropertyRegistry) HomeAirConditioner() PropertyTable {
 				NameTranslations: map[string]string{
 					"ja": "室内相対湿度計測値",
 				},
-				Aliases:           ExtraValueAlias,
-				AliasTranslations: ExtraValueAliasTranslations,
+				Aliases:           UnsignedExtraValueAlias,
+				AliasTranslations: UnsignedExtraValueAliasTranslations,
 				Decoder:           HumidityDesc,
 			},
 			EPC_HAC_CurrentRoomTemperature: {
@@ -139,8 +155,8 @@ func (r PropertyRegistry) HomeAirConditioner() PropertyTable {
 				NameTranslations: map[string]string{
 					"ja": "室内温度計測値",
 				},
-				Aliases:           ExtraValueAlias,
-				AliasTranslations: ExtraValueAliasTranslations,
+				Aliases:           MeasuredTemperatureExtraValueAlias,
+				AliasTranslations: MeasuredTemperatureExtraValueAliasTranslations,
 				Decoder:           MeasuredTemperatureDesc,
 			},
 			EPC_HAC_CurrentOutsideTemperature: {
@@ -148,8 +164,8 @@ func (r PropertyRegistry) HomeAirConditioner() PropertyTable {
 				NameTranslations: map[string]string{
 					"ja": "屋外温度計測値",
 				},
-				Aliases:           ExtraValueAlias,
-				AliasTranslations: ExtraValueAliasTranslations,
+				Aliases:           MeasuredTemperatureExtraValueAlias,
+				AliasTranslations: MeasuredTemperatureExtraValueAliasTranslations,
 				Decoder:           MeasuredTemperatureDesc,
 			},
 			EPC_HAC_HumidificationModeSetting: {


### PR DESCRIPTION
## Summary

Fixes temperature sensor display issue where 0x7E values were showing as "Raw data" instead of "N/A".

- Separated signed/unsigned alias definitions for proper 8-bit value handling
- Applied appropriate aliases to temperature measurement vs setting properties
- Temperature sensors now correctly display "N/A" for unmeasurable values (0x7E)

## Changes

### Root Cause
HomeAirConditioner was using a single `ExtraValueAlias` map for both signed and unsigned 8-bit values:
- **Measured temperature** (signed): 0x7E = 126 = N/A
- **Setting temperature/humidity** (unsigned): 0xFD = 253 = unknown

### Solution
Split into two separate alias maps:

1. **MeasuredTemperatureExtraValueAlias** (signed 8-bit)
   - 0x7E = "N/A" 
   - 0x7F = "overflow"
   - 0x80 = "underflow"

2. **UnsignedExtraValueAlias** (unsigned 8-bit)  
   - 0xFD = "unknown"
   - 0xFE = "underflow" 
   - 0xFF = "overflow"

### Properties Updated
- **CurrentRoomTemperature, CurrentOutsideTemperature**: Use signed aliases
- **TemperatureSetting, RelativeHumiditySetting, CurrentRoomHumidity**: Use unsigned aliases

## Test Plan

- [x] Go build successful
- [x] Go tests pass (all cached)
- [x] Go vet clean
- [x] Web UI lint clean  
- [x] Web UI typecheck clean
- [x] Web UI tests pass (486/486)
- [x] Web UI build successful

🤖 Generated with [Claude Code](https://claude.ai/code)