### PR TITLE
Fix shellcheck warnings in shell scripts

### DIFF
--- a/script/uninstall-systemd.sh
+++ b/script/uninstall-systemd.sh
@@ -6,7 +6,6 @@
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 # 設定
 SERVICE_NAME="echonet-list"

--- a/script/update.sh
+++ b/script/update.sh
@@ -13,7 +13,6 @@ SERVICE_NAME="echonet-list"
 SERVICE_USER="echonet"
 SERVICE_GROUP="echonet"
 INSTALL_DIR="/usr/local/bin"
-CONFIG_DIR="/etc/echonet-list"
 DATA_DIR="/var/lib/echonet-list"
 WEB_DIR="/usr/local/share/echonet-list/web"
 
@@ -106,7 +105,7 @@ chmod 755 "$INSTALL_DIR/echonet-list"
 # Web UI更新
 print_info "Web UIファイルを更新しています..."
 if [[ -d "$WEB_DIR" ]]; then
-    rm -rf "$WEB_DIR"/*
+    rm -rf "${WEB_DIR:?}"/*
 fi
 mkdir -p "$WEB_DIR"
 cp -r "$WEB_BUNDLE_DIR"/* "$WEB_DIR/"
@@ -164,7 +163,7 @@ if [[ "$WAS_ACTIVE" == "true" ]]; then
             cp "$BACKUP_DIR/echonet-list" "$INSTALL_DIR/"
         fi
         if [[ -d "$BACKUP_DIR/web-bundle" ]]; then
-            rm -rf "$WEB_DIR"/*
+            rm -rf "${WEB_DIR:?}"/*
             cp -r "$BACKUP_DIR/web-bundle"/* "$WEB_DIR/"
         fi
         


### PR DESCRIPTION
## Summary

- Fixed shellcheck warnings in deployment and maintenance shell scripts
- Removed unused variables and improved safety of file operations
- All scripts now pass shellcheck analysis without warnings

## Changes Made

### script/uninstall-systemd.sh
- Removed unused `PROJECT_DIR` variable (SC2034 warning)

### script/update.sh  
- Removed unused `CONFIG_DIR` variable (SC2034 warning)
- Changed `rm -rf "$WEB_DIR"/*` to `rm -rf "${WEB_DIR:?}"/*` for safer file deletion (SC2115 warning)
  - This prevents accidental deletion if the WEB_DIR variable becomes empty

## Test Plan

- [x] All shell scripts pass shellcheck analysis with no warnings
- [x] Go server builds and tests pass
- [x] Web UI builds and tests pass
- [x] No functional changes to script behavior

## Safety Improvements

The `${WEB_DIR:?}` syntax ensures the script will exit with an error if the WEB_DIR variable is empty or unset, preventing accidental deletion of files in the root directory.

🤖 Generated with [Claude Code](https://claude.ai/code)