### PR TITLE
ci: update Go version from 1.23 to 1.24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.23"
+          go-version: "1.24"
 
       - name: Cache Go modules
         uses: actions/cache@v4
@@ -183,7 +183,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.23"
+          go-version: "1.24"
 
       - name: Cache Go modules
         uses: actions/cache@v4


### PR DESCRIPTION
## Summary
• Update GitHub Actions workflow to use Go 1.24 instead of 1.23
• Align CI environment with go.mod toolchain specification (go1.24.1)
• Apply changes to both go-server and integration test jobs

## Test plan
- [x] Go precheck: fmt, vet, test, build - all passed
- [x] Web UI precheck: lint, typecheck, test, build - all passed
- [ ] CI validation: verify Go 1.24 is used in GitHub Actions

🤖 Generated with [Claude Code](https://claude.ai/code)