### PR TITLE
fix: support zero values in PropertyInputControl numeric input

### DIFF
--- a/server/websocket_server_handlers_properties.go
+++ b/server/websocket_server_handlers_properties.go
@@ -170,16 +170,16 @@ func (ws *WebSocketServer) handleSetPropertiesFromClient(msg *protocol.Message) 
 			edtBytes = decoded
 		}
 		switch {
-		case propData.String != "" && propData.Number != 0:
+		case propData.String != "" && propData.Number != nil:
 			// StringとNumberの両方があったらエラー
 			return ErrorResponse(protocol.ErrorCodeInvalidParameters, "Conflicting string and number for EPC: %s", epcStr)
-		case propData.Number != 0:
+		case propData.Number != nil:
 			converter, ok := desc.Decoder.(echonet_lite.PropertyIntConverter)
 			if !ok {
 				// 数値に対応していないEPCに数値が与えられたエラー
 				return ErrorResponse(protocol.ErrorCodeInvalidParameters, "Invalid number field for EPC %s", epcStr)
 			}
-			converted, ok := converter.FromInt(propData.Number)
+			converted, ok := converter.FromInt(*propData.Number)
 			if !ok {
 				// 装置が範囲外
 				return ErrorResponse(protocol.ErrorCodeInvalidParameters, "Invalid number value for EPC %s", epcStr)

--- a/server/websocket_server_handlers_set_properties_test.go
+++ b/server/websocket_server_handlers_set_properties_test.go
@@ -9,6 +9,11 @@ import (
 	"echonet-list/protocol"
 )
 
+// Helper function to create int pointers
+func intPtr(i int) *int {
+	return &i
+}
+
 // TestHandleSetPropertiesFromClient covers four scenarios:
 // 1. EDT only
 // 2. String only
@@ -59,7 +64,17 @@ func TestHandleSetPropertiesFromClient(t *testing.T) {
 			payload: protocol.SetPropertiesPayload{
 				Target: "192.168.1.10 0130:1",
 				Properties: protocol.PropertyMap{
-					"B3": {Number: 25}, // Set temperature to 25 using Number
+					"B3": {Number: intPtr(25)}, // Set temperature to 25 using Number
+				},
+			},
+			wantError: false,
+		},
+		{
+			name: "Number with zero value",
+			payload: protocol.SetPropertiesPayload{
+				Target: "192.168.1.10 0130:1",
+				Properties: protocol.PropertyMap{
+					"B3": {Number: intPtr(0)}, // Set temperature to 0 using Number
 				},
 			},
 			wantError: false,
@@ -96,7 +111,7 @@ func TestHandleSetPropertiesFromClient(t *testing.T) {
 				Properties: protocol.PropertyMap{
 					"B3": {
 						String: "25",
-						Number: 20, // Conflicting values
+						Number: intPtr(20), // Conflicting values
 					},
 				},
 			},


### PR DESCRIPTION
## Summary

Fixed a critical bug where setting 0 in PropertyInputControl would cause a server error "No EDT or string specified for EPC". The issue was caused by the server checking `propData.Number != 0` which treated 0 as an unset value.

## Changes

- **Protocol Layer**: Changed `PropertyData.Number` from `int` to `*int` to distinguish between nil (unset) and 0 (zero value)
- **Server Logic**: Updated condition checks from `!= 0` to `!= nil` and added pointer dereferencing
- **Protocol Conversion**: Modified `MakePropertyData` to use pointer types
- **Test Coverage**: Added comprehensive test case for zero value handling

## Test Results

✅ **Go Tests**: All tests pass including new zero value test case  
✅ **Web UI Tests**: All 498 tests pass  
✅ **TypeScript**: Type checking passes  
✅ **Linting**: No lint errors  
✅ **Build**: Both Go and Web UI build successfully  

## Verification

The fix allows users to successfully set numeric properties to 0 through the PropertyInputControl without encountering server errors. This resolves the issue identified in the Web UI where 0 values were being rejected.

🤖 Generated with [Claude Code](https://claude.ai/code)