### PR TITLE
feat(server): add in-memory device history store

### DIFF
--- a/config.toml.sample
+++ b/config.toml.sample
@@ -7,6 +7,11 @@ debug = false
 [log]
 filename = "echonet-list.log"
 
+# 履歴設定
+[history]
+# デバイスごとに保持する履歴件数の上限
+per_device_limit = 500
+
 # WebSocketサーバー設定
 [websocket]
 enabled = true

--- a/config/config.go
+++ b/config/config.go
@@ -60,6 +60,9 @@ type Config struct {
 	Log   struct {
 		Filename string `toml:"filename"`
 	} `toml:"log"`
+	History struct {
+		PerDeviceLimit int `toml:"per_device_limit"`
+	} `toml:"history"`
 	WebSocket struct {
 		Enabled                bool   `toml:"enabled"`
 		PeriodicUpdateInterval string `toml:"periodic_update_interval"` // e.g., "1m", "30s", "0" to disable
@@ -106,6 +109,7 @@ func NewConfig() *Config {
 		Debug: false,
 	}
 	cfg.Log.Filename = "echonet-list.log"
+	cfg.History.PerDeviceLimit = 500
 	cfg.WebSocket.PeriodicUpdateInterval = "1m" // Default to 1 minute
 	cfg.WebSocket.ForcedUpdateInterval = "30m"  // Default to 30 minutes
 	cfg.WebSocketClient.Addr = "ws://localhost:8080/ws"

--- a/main.go
+++ b/main.go
@@ -136,7 +136,14 @@ func main() {
 		httpAddr := fmt.Sprintf("%s:%d", cfg.HTTPServer.Host, cfg.HTTPServer.Port)
 
 		// WebSocketサーバーの作成と起動
-		wsServer, err := server.NewWebSocketServer(ctx, httpAddr, client.NewECHONETListClientProxy(s.GetHandler()), s.GetHandler(), serverStartupTime)
+		wsServer, err := server.NewWebSocketServer(
+			ctx,
+			httpAddr,
+			client.NewECHONETListClientProxy(s.GetHandler()),
+			s.GetHandler(),
+			serverStartupTime,
+			server.HistoryOptions{PerDeviceLimit: cfg.History.PerDeviceLimit},
+		)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "WebSocketサーバーの作成に失敗しました: %v\n", err)
 			os.Exit(1)

--- a/server/device_history_store.go
+++ b/server/device_history_store.go
@@ -1,0 +1,153 @@
+package server
+
+import (
+	"sync"
+	"time"
+
+	"echonet-list/echonet_lite"
+	"echonet-list/echonet_lite/handler"
+	"echonet-list/protocol"
+)
+
+// HistoryOrigin identifies how a history entry was produced.
+type HistoryOrigin string
+
+const (
+	// HistoryOriginNotification indicates that the entry came from a property change notification.
+	HistoryOriginNotification HistoryOrigin = "notification"
+	// HistoryOriginSet indicates that the entry came from a successful set_properties operation.
+	HistoryOriginSet HistoryOrigin = "set"
+)
+
+// DeviceHistoryEntry represents a single history item for a device.
+type DeviceHistoryEntry struct {
+	Timestamp time.Time
+	Device    handler.IPAndEOJ
+	EPC       echonet_lite.EPCType
+	Value     protocol.PropertyData
+	Origin    HistoryOrigin
+	Settable  bool
+}
+
+// HistoryQuery specifies filters applied when fetching history entries.
+type HistoryQuery struct {
+	Since        time.Time
+	Limit        int
+	SettableOnly bool
+}
+
+// DeviceHistoryStore defines behaviour required from a history backend.
+type DeviceHistoryStore interface {
+	Record(entry DeviceHistoryEntry)
+	Query(device handler.IPAndEOJ, query HistoryQuery) []DeviceHistoryEntry
+	Clear(device handler.IPAndEOJ)
+	PerDeviceLimit() int
+}
+
+// HistoryOptions configures the behaviour of the history store.
+type HistoryOptions struct {
+	PerDeviceLimit int
+}
+
+// DefaultHistoryOptions returns the default options used when none are provided.
+func DefaultHistoryOptions() HistoryOptions {
+	return HistoryOptions{
+		PerDeviceLimit: 500,
+	}
+}
+
+// newMemoryDeviceHistoryStore constructs an in-memory store.
+func newMemoryDeviceHistoryStore(opts HistoryOptions) *memoryDeviceHistoryStore {
+	options := DefaultHistoryOptions()
+	if opts.PerDeviceLimit > 0 {
+		options.PerDeviceLimit = opts.PerDeviceLimit
+	}
+
+	return &memoryDeviceHistoryStore{
+		perDeviceLimit: options.PerDeviceLimit,
+		data:           make(map[string][]DeviceHistoryEntry),
+	}
+}
+
+type memoryDeviceHistoryStore struct {
+	mu             sync.RWMutex
+	perDeviceLimit int
+	data           map[string][]DeviceHistoryEntry
+}
+
+func (s *memoryDeviceHistoryStore) Record(entry DeviceHistoryEntry) {
+	if entry.Device.IP == nil {
+		return
+	}
+
+	key := entry.Device.Key()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	entries := append(s.data[key], entry)
+
+	if limit := s.perDeviceLimit; limit > 0 && len(entries) > limit {
+		// Drop oldest entries to enforce the cap.
+		entries = entries[len(entries)-limit:]
+	}
+
+	s.data[key] = entries
+}
+
+func (s *memoryDeviceHistoryStore) Query(device handler.IPAndEOJ, query HistoryQuery) []DeviceHistoryEntry {
+	key := device.Key()
+
+	s.mu.RLock()
+	entries, ok := s.data[key]
+	s.mu.RUnlock()
+	if !ok || len(entries) == 0 {
+		return nil
+	}
+
+	limit := query.Limit
+	if limit <= 0 {
+		limit = len(entries)
+	}
+
+	result := make([]DeviceHistoryEntry, 0, min(limit, len(entries)))
+	since := query.Since
+
+	// Iterate from newest to oldest so the result is ordered newest-first.
+	for i := len(entries) - 1; i >= 0; i-- {
+		entry := entries[i]
+
+		if !since.IsZero() && entry.Timestamp.Before(since) {
+			continue
+		}
+		if query.SettableOnly && !entry.Settable {
+			continue
+		}
+
+		result = append(result, entry)
+		if len(result) >= limit {
+			break
+		}
+	}
+
+	return result
+}
+
+func (s *memoryDeviceHistoryStore) Clear(device handler.IPAndEOJ) {
+	key := device.Key()
+
+	s.mu.Lock()
+	delete(s.data, key)
+	s.mu.Unlock()
+}
+
+func (s *memoryDeviceHistoryStore) PerDeviceLimit() int {
+	return s.perDeviceLimit
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/server/device_history_store_test.go
+++ b/server/device_history_store_test.go
@@ -1,0 +1,128 @@
+package server
+
+import (
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"echonet-list/echonet_lite"
+	"echonet-list/echonet_lite/handler"
+	"echonet-list/protocol"
+)
+
+func TestMemoryDeviceHistoryStore_RecordEnforcesLimit(t *testing.T) {
+	store := newMemoryDeviceHistoryStore(HistoryOptions{PerDeviceLimit: 3})
+	device := testDevice(1)
+	base := time.Now()
+
+	for i := 0; i < 5; i++ {
+		store.Record(DeviceHistoryEntry{
+			Timestamp: base.Add(time.Duration(i) * time.Minute),
+			Device:    device,
+			EPC:       echonet_lite.EPCType(0x80),
+			Value: protocol.PropertyData{
+				String: fmt.Sprintf("value-%d", i),
+			},
+			Origin:   HistoryOriginNotification,
+			Settable: true,
+		})
+	}
+
+	entries := store.Query(device, HistoryQuery{})
+
+	if len(entries) != 3 {
+		t.Fatalf("expected 3 entries, got %d", len(entries))
+	}
+
+	// Should be newest first: indices 4,3,2
+	for i, expected := range []string{"value-4", "value-3", "value-2"} {
+		if entries[i].Value.String != expected {
+			t.Errorf("entry %d expected value %s, got %s", i, expected, entries[i].Value.String)
+		}
+	}
+}
+
+func TestMemoryDeviceHistoryStore_QueryFilters(t *testing.T) {
+	store := newMemoryDeviceHistoryStore(HistoryOptions{PerDeviceLimit: 10})
+	device := testDevice(2)
+	base := time.Now()
+
+	entries := []DeviceHistoryEntry{
+		{
+			Timestamp: base.Add(-3 * time.Hour),
+			Device:    device,
+			EPC:       echonet_lite.EPCType(0xA0),
+			Value:     protocol.PropertyData{String: "old"},
+			Origin:    HistoryOriginNotification,
+			Settable:  true,
+		},
+		{
+			Timestamp: base.Add(-2 * time.Hour),
+			Device:    device,
+			EPC:       echonet_lite.EPCType(0xA1),
+			Value:     protocol.PropertyData{String: "no-set"},
+			Origin:    HistoryOriginNotification,
+			Settable:  false,
+		},
+		{
+			Timestamp: base.Add(-1 * time.Hour),
+			Device:    device,
+			EPC:       echonet_lite.EPCType(0xA2),
+			Value:     protocol.PropertyData{String: "recent"},
+			Origin:    HistoryOriginSet,
+			Settable:  true,
+		},
+	}
+
+	for _, entry := range entries {
+		store.Record(entry)
+	}
+
+	result := store.Query(device, HistoryQuery{
+		Since:        base.Add(-90 * time.Minute),
+		SettableOnly: true,
+		Limit:        5,
+	})
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(result))
+	}
+
+	if result[0].Value.String != "recent" {
+		t.Fatalf("expected 'recent', got %s", result[0].Value.String)
+	}
+}
+
+func TestMemoryDeviceHistoryStore_Clear(t *testing.T) {
+	store := newMemoryDeviceHistoryStore(HistoryOptions{PerDeviceLimit: 5})
+	device := testDevice(3)
+
+	store.Record(DeviceHistoryEntry{
+		Timestamp: time.Now(),
+		Device:    device,
+		EPC:       echonet_lite.EPCType(0x80),
+		Value:     protocol.PropertyData{String: "value"},
+		Origin:    HistoryOriginNotification,
+		Settable:  true,
+	})
+
+	if entries := store.Query(device, HistoryQuery{}); len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+
+	store.Clear(device)
+
+	if entries := store.Query(device, HistoryQuery{}); len(entries) != 0 {
+		t.Fatalf("expected 0 entry after clear, got %d", len(entries))
+	}
+}
+
+func testDevice(id int) handler.IPAndEOJ {
+	ip := net.ParseIP(fmt.Sprintf("192.0.2.%d", id))
+	eoj := echonet_lite.MakeEOJ(echonet_lite.EOJClassCode(0x0130), echonet_lite.EOJInstanceCode(id))
+	return handler.IPAndEOJ{
+		IP:  ip,
+		EOJ: eoj,
+	}
+}

--- a/server/websocket_server_history_test.go
+++ b/server/websocket_server_history_test.go
@@ -1,0 +1,90 @@
+package server
+
+import (
+	"encoding/base64"
+	"testing"
+	"time"
+
+	"echonet-list/echonet_lite"
+	"echonet-list/echonet_lite/handler"
+	"echonet-list/protocol"
+)
+
+func TestWebSocketServer_RecordPropertyChange(t *testing.T) {
+	store := newMemoryDeviceHistoryStore(DefaultHistoryOptions())
+	ws := &WebSocketServer{
+		historyStore: store,
+	}
+
+	device := testDevice(10)
+	change := handler.PropertyChangeNotification{
+		Device: device,
+		Property: echonet_lite.Property{
+			EPC: echonet_lite.EPCType(0x80),
+			EDT: []byte{0x30},
+		},
+	}
+
+	ws.recordPropertyChange(change)
+
+	entries := store.Query(device, HistoryQuery{})
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+
+	entry := entries[0]
+	if entry.Origin != HistoryOriginNotification {
+		t.Fatalf("expected origin %s, got %s", HistoryOriginNotification, entry.Origin)
+	}
+	if entry.Value.EDT != base64.StdEncoding.EncodeToString([]byte{0x30}) {
+		t.Fatalf("unexpected EDT value %q", entry.Value.EDT)
+	}
+}
+
+func TestWebSocketServer_RecordSetResult(t *testing.T) {
+	store := newMemoryDeviceHistoryStore(DefaultHistoryOptions())
+	ws := &WebSocketServer{
+		historyStore: store,
+	}
+
+	device := testDevice(11)
+	value := protocol.PropertyData{
+		String: "on",
+	}
+
+	ws.recordSetResult(device, echonet_lite.EPCType(0x80), value)
+
+	entries := store.Query(device, HistoryQuery{})
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	entry := entries[0]
+	if entry.Origin != HistoryOriginSet {
+		t.Fatalf("expected origin %s, got %s", HistoryOriginSet, entry.Origin)
+	}
+	if entry.Value.String != "on" {
+		t.Fatalf("unexpected value %s", entry.Value.String)
+	}
+}
+
+func TestWebSocketServer_ClearHistoryForDevice(t *testing.T) {
+	store := newMemoryDeviceHistoryStore(DefaultHistoryOptions())
+	ws := &WebSocketServer{
+		historyStore: store,
+	}
+
+	device := testDevice(12)
+	store.Record(DeviceHistoryEntry{
+		Timestamp: time.Now(),
+		Device:    device,
+		EPC:       echonet_lite.EPCType(0xA0),
+		Value:     protocol.PropertyData{String: "value"},
+		Origin:    HistoryOriginNotification,
+	})
+
+	ws.clearHistoryForDevice(device)
+
+	if entries := store.Query(device, HistoryQuery{}); len(entries) != 0 {
+		t.Fatalf("expected 0 entries, got %d", len(entries))
+	}
+}


### PR DESCRIPTION
## Summary
- add configurable per-device history retention and integrate with websocket server
- record property change and successful set events with origin/settable metadata
- expose defaults in config and document history settings

## Testing
- go test ./...

Closes #283