### PR TITLE
feat(websocket): add get_device_history API

### DIFF
--- a/docs/websocket_client_protocol.md
+++ b/docs/websocket_client_protocol.md
@@ -643,6 +643,67 @@ case 'device_added':
 
 - `target`: デバイスID文字列（IP EOJ形式）
 
+### get_device_history
+
+指定したデバイスの最近の履歴を取得します（サーバーのオンメモリ履歴ストアから取得）。
+
+```json
+{
+  "type": "get_device_history",
+  "payload": {
+    "target": "192.168.1.10 0130:1",
+    "limit": 50,               // オプション: 取得件数の上限（既定値 50, サーバー設定値を超える場合は丸め込み）
+    "since": "2024-05-01T00:00:00Z", // オプション: この日時以降の履歴のみを取得（RFC3339 / RFC3339Nano）
+    "settableOnly": true       // オプション: true で Set Property Map に含まれる履歴のみ（既定 true）
+  },
+  "requestId": "req-129"
+}
+```
+
+- `target`: デバイスID文字列（IP EOJ形式）。必須。
+- `limit`: 取得件数の上限。正の整数のみ許容。省略時は 50。
+- `since`: 絞り込み開始時刻。RFC3339 / RFC3339Nano 形式。省略時は全履歴。
+- `settableOnly`: `true` の場合、Set Property Map に含まれるプロパティのみ返します。省略時は `true`。
+
+レスポンスは `command_result` メッセージの `data` フィールドに以下の形式で返されます：
+
+```json
+{
+  "type": "command_result",
+  "payload": {
+    "success": true,
+    "data": {
+      "entries": [
+        {
+          "timestamp": "2024-05-01T12:34:56.789Z",
+          "epc": "80",
+          "value": { "string": "on", "EDT": "MzA=" },
+          "origin": "set",
+          "settable": true
+        },
+        {
+          "timestamp": "2024-05-01T12:35:10.123Z",
+          "epc": "B0",
+          "value": { "number": 24, "EDT": "Eg==" },
+          "origin": "notification",
+          "settable": true
+        }
+      ]
+    }
+  },
+  "requestId": "req-129"
+}
+```
+
+- `entries`: 履歴の配列。新しい順で返されます。
+- `timestamp`: ISO 8601 / RFC3339 形式の時刻 (UTC)。
+- `epc`: 履歴対象の EPC（2桁16進数文字列）。
+- `value`: プロパティ値 (`PropertyData` と同形式)。
+- `origin`: `"set"`（set_properties による更新）または `"notification"`（プロパティ変化通知）。
+- `settable`: Set Property Map に含まれるプロパティなら `true`。
+
+デバイスが存在しない場合やパラメータが不正な場合は `success: false` となり、`error` に詳細が入ります。
+
 **重要な動作仕様**:
 - **NodeProfile削除時**: 指定したデバイスのクラスコードが`0x0ef0`（NodeProfile）の場合、同一IPアドレスのすべてのデバイスが削除されます
 - **通常デバイス削除時**: 指定したデバイスのみが削除されます

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -16,6 +16,30 @@ type PropertyData struct {
 	Number *int   `json:"number,omitempty"` // Numeric value, omitted if nil. Only usable when PropertyDesc has NumberDesc.
 }
 
+// HistoryOrigin identifies the source of a history entry.
+type HistoryOrigin string
+
+const (
+	// HistoryOriginNotification indicates that the entry originated from a property change notification.
+	HistoryOriginNotification HistoryOrigin = "notification"
+	// HistoryOriginSet indicates that the entry originated from a set_properties command.
+	HistoryOriginSet HistoryOrigin = "set"
+)
+
+// HistoryEntry represents a single history record for a device.
+type HistoryEntry struct {
+	Timestamp time.Time     `json:"timestamp"`
+	EPC       string        `json:"epc"`
+	Value     PropertyData  `json:"value"`
+	Origin    HistoryOrigin `json:"origin"`
+	Settable  bool          `json:"settable"`
+}
+
+// DeviceHistoryResponse is the payload returned for get_device_history.
+type DeviceHistoryResponse struct {
+	Entries []HistoryEntry `json:"entries"`
+}
+
 // MessageType defines the type of message being sent between client and server
 type MessageType string
 
@@ -44,6 +68,7 @@ const (
 	MessageTypeGetPropertyDescription MessageType = "get_property_description"
 	MessageTypeDeleteDevice           MessageType = "delete_device"
 	MessageTypeDebugSetOffline        MessageType = "debug_set_offline"
+	MessageTypeGetDeviceHistory       MessageType = "get_device_history"
 )
 
 // AliasChangeType defines the type of alias change
@@ -192,6 +217,14 @@ type SetPropertiesPayload struct {
 type UpdatePropertiesPayload struct {
 	Targets []string `json:"targets"`
 	Force   bool     `json:"force,omitempty"`
+}
+
+// GetDeviceHistoryPayload is the payload for the get_device_history message
+type GetDeviceHistoryPayload struct {
+	Target       string `json:"target"`
+	Limit        *int   `json:"limit,omitempty"`
+	Since        string `json:"since,omitempty"`
+	SettableOnly *bool  `json:"settableOnly,omitempty"`
 }
 
 // ManageAliasPayload is the payload for the manage_alias message

--- a/server/websocket_server_handlers_history.go
+++ b/server/websocket_server_handlers_history.go
@@ -1,0 +1,110 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"echonet-list/echonet_lite/handler"
+	"echonet-list/protocol"
+)
+
+const defaultHistoryLimit = 50
+
+func parseHistorySince(value string) (time.Time, error) {
+	if value == "" {
+		return time.Time{}, nil
+	}
+
+	if ts, err := time.Parse(time.RFC3339Nano, value); err == nil {
+		return ts, nil
+	}
+	return time.Parse(time.RFC3339, value)
+}
+
+// handleGetDeviceHistoryFromClient handles a get_device_history message from a client.
+func (ws *WebSocketServer) handleGetDeviceHistoryFromClient(msg *protocol.Message) protocol.CommandResultPayload {
+	if ws.historyStore == nil {
+		return ErrorResponse(protocol.ErrorCodeInternalServerError, "History store is not available")
+	}
+
+	var payload protocol.GetDeviceHistoryPayload
+	if err := protocol.ParsePayload(msg, &payload); err != nil {
+		return ErrorResponse(protocol.ErrorCodeInvalidRequestFormat, "Error parsing get_device_history payload: %v", err)
+	}
+
+	target := strings.TrimSpace(payload.Target)
+	if target == "" {
+		return ErrorResponse(protocol.ErrorCodeInvalidParameters, "No target specified")
+	}
+
+	ipAndEOJ, err := handler.ParseDeviceIdentifier(target)
+	if err != nil {
+		return ErrorResponse(protocol.ErrorCodeInvalidParameters, "Invalid target: %v", err)
+	}
+
+	if ws.deviceResolver == nil {
+		return ErrorResponse(protocol.ErrorCodeInternalServerError, "Handler is not available")
+	}
+
+	if !ws.deviceResolver(ipAndEOJ) {
+		return ErrorResponse(protocol.ErrorCodeInvalidParameters, "Unknown device: %s", target)
+	}
+
+	limit := defaultHistoryLimit
+	if payload.Limit != nil {
+		if *payload.Limit <= 0 {
+			return ErrorResponse(protocol.ErrorCodeInvalidParameters, "Limit must be greater than zero")
+		}
+		limit = *payload.Limit
+	}
+
+	if storeLimit := ws.historyStore.PerDeviceLimit(); storeLimit > 0 && limit > storeLimit {
+		limit = storeLimit
+	}
+
+	since := time.Time{}
+	if payload.Since != "" {
+		var err error
+		since, err = parseHistorySince(payload.Since)
+		if err != nil {
+			return ErrorResponse(protocol.ErrorCodeInvalidParameters, "Invalid since value: %v", err)
+		}
+	}
+
+	settableOnly := true
+	if payload.SettableOnly != nil {
+		settableOnly = *payload.SettableOnly
+	}
+
+	query := HistoryQuery{
+		Since:        since,
+		Limit:        limit,
+		SettableOnly: settableOnly,
+	}
+
+	history := ws.historyStore.Query(ipAndEOJ, query)
+	resultEntries := make([]protocol.HistoryEntry, 0, len(history))
+
+	for _, entry := range history {
+		resultEntries = append(resultEntries, protocol.HistoryEntry{
+			Timestamp: entry.Timestamp,
+			EPC:       fmt.Sprintf("%02X", byte(entry.EPC)),
+			Value:     entry.Value,
+			Origin:    protocol.HistoryOrigin(entry.Origin),
+			Settable:  entry.Settable,
+		})
+	}
+
+	response := protocol.DeviceHistoryResponse{
+		Entries: resultEntries,
+	}
+
+	data, err := json.Marshal(response)
+	if err != nil {
+		return ErrorResponse(protocol.ErrorCodeInternalServerError, "Error marshaling history data: %v", err)
+	}
+
+	return SuccessResponse(data)
+}

--- a/server/websocket_server_handlers_history_test.go
+++ b/server/websocket_server_handlers_history_test.go
@@ -1,0 +1,109 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"echonet-list/echonet_lite"
+	"echonet-list/protocol"
+)
+
+func TestHandleGetDeviceHistoryFromClient_Success(t *testing.T) {
+	ctx := context.Background()
+	device := testDevice(20)
+
+	store := newMemoryDeviceHistoryStore(HistoryOptions{PerDeviceLimit: 10})
+	ws := &WebSocketServer{
+		ctx:          ctx,
+		historyStore: store,
+		deviceResolver: func(d echonet_lite.IPAndEOJ) bool {
+			return d.Specifier() == device.Specifier()
+		},
+	}
+
+	ws.historyStore.Record(DeviceHistoryEntry{
+		Timestamp: time.Now().UTC(),
+		Device:    device,
+		EPC:       echonet_lite.EPCType(0x80),
+		Value:     protocol.PropertyData{String: "on"},
+		Origin:    HistoryOriginSet,
+		Settable:  true,
+	})
+
+	payload := protocol.GetDeviceHistoryPayload{
+		Target: device.Specifier(),
+	}
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("failed to marshal payload: %v", err)
+	}
+
+	result := ws.handleGetDeviceHistoryFromClient(&protocol.Message{
+		Type:    protocol.MessageTypeGetDeviceHistory,
+		Payload: payloadBytes,
+	})
+
+	if !result.Success {
+		t.Fatalf("expected success, got error: %v", result.Error)
+	}
+
+	var response protocol.DeviceHistoryResponse
+	if err := json.Unmarshal(result.Data, &response); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+
+	if len(response.Entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(response.Entries))
+	}
+
+	entry := response.Entries[0]
+	if entry.EPC != "80" {
+		t.Fatalf("expected EPC 80, got %s", entry.EPC)
+	}
+	if entry.Origin != protocol.HistoryOriginSet {
+		t.Fatalf("expected origin set, got %s", entry.Origin)
+	}
+	if !entry.Settable {
+		t.Fatalf("expected settable true")
+	}
+	if entry.Value.String != "on" {
+		t.Fatalf("expected value 'on', got %s", entry.Value.String)
+	}
+}
+
+func TestHandleGetDeviceHistoryFromClient_InvalidLimit(t *testing.T) {
+	ctx := context.Background()
+	device := testDevice(21)
+
+	ws := &WebSocketServer{
+		ctx:          ctx,
+		historyStore: newMemoryDeviceHistoryStore(DefaultHistoryOptions()),
+		deviceResolver: func(d echonet_lite.IPAndEOJ) bool {
+			return d.Specifier() == device.Specifier()
+		},
+	}
+
+	limit := 0
+	payload := protocol.GetDeviceHistoryPayload{
+		Target: device.Specifier(),
+		Limit:  &limit,
+	}
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("failed to marshal payload: %v", err)
+	}
+
+	result := ws.handleGetDeviceHistoryFromClient(&protocol.Message{
+		Type:    protocol.MessageTypeGetDeviceHistory,
+		Payload: payloadBytes,
+	})
+
+	if result.Success {
+		t.Fatalf("expected failure due to invalid limit")
+	}
+	if result.Error == nil || result.Error.Code != protocol.ErrorCodeInvalidParameters {
+		t.Fatalf("expected invalid parameters error, got %+v", result.Error)
+	}
+}

--- a/web/src/hooks/types.ts
+++ b/web/src/hooks/types.ts
@@ -16,6 +16,16 @@ export type PropertyValue = {
   number?: number; // Numeric representation (if NumberDesc exists)
 };
 
+export type HistoryOrigin = 'notification' | 'set';
+
+export type DeviceHistoryEntry = {
+  timestamp: string;
+  epc: string;
+  value: PropertyValue;
+  origin: HistoryOrigin;
+  settable: boolean;
+};
+
 export type DeviceAlias = Record<string, string>; // alias -> device ID string
 export type DeviceGroup = Record<string, string[]>; // group name -> device ID strings
 
@@ -176,6 +186,13 @@ export type DeleteDeviceRequest = BaseRequest<{
   target: string; // device ID string (IP EOJ format)
 }>;
 
+export type GetDeviceHistoryRequest = BaseRequest<{
+  target: string;
+  limit?: number;
+  since?: string;
+  settableOnly?: boolean;
+}>;
+
 export type ClientMessage = 
   | GetPropertiesRequest
   | SetPropertiesRequest
@@ -184,7 +201,8 @@ export type ClientMessage =
   | ManageGroupRequest
   | DiscoverDevicesRequest
   | GetPropertyDescriptionRequest
-  | DeleteDeviceRequest;
+  | DeleteDeviceRequest
+  | GetDeviceHistoryRequest;
 
 // Command Result Response
 export type CommandResult = {


### PR DESCRIPTION
## Summary
- add protocol types and docs for the new get_device_history request/response
- implement server handler that validates input, queries the history store, and returns protocol entries
- extend TypeScript protocol types for the history request and value metadata

## Testing
- go test ./server ./protocol

Closes #284