### PR TITLE
docs: update CLAUDE.md with history feature documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,11 @@ Web UI のビルド結果は `web/bundle/` に出力され、Go サーバーがH
 - **プロパティ表示改善**: EPCコードを人間可読な名前で表示
 - **インタラクティブ編集**: プロパティ種類に応じたUIコントロール（ドロップダウン、数値入力）
 - **デバイスエイリアス表示**: エイリアス名での分かりやすいデバイス識別
+- **デバイス履歴表示**: 各デバイスのプロパティ変更履歴を表示
+  - デバイスカードから履歴ボタン（時計アイコン）でダイアログを開く
+  - 時刻、プロパティ名、値、発生源（操作/通知）を時系列表示
+  - settableOnlyフィルターで操作可能プロパティのみ/全プロパティを切り替え
+  - リロードボタンで履歴の再取得
 - **レスポンシブデザイン**: モバイル・デスクトップ対応
 - **リアルタイム更新**: WebSocketによるプロパティ変更のリアルタイム反映
 - **国際化対応**: 日本語・英語対応のプロパティ表示（`get_property_description` API の `lang` パラメータ）
@@ -69,8 +74,10 @@ Web UI のビルド結果は `web/bundle/` に出力され、Go サーバーがH
   - `src/App.tsx`: メインアプリケーション
   - `src/components/PropertyEditor.tsx`: プロパティ編集コンポーネント
   - `src/components/DeviceStatusIndicators.tsx`: デバイス状態インジケータ
+  - `src/components/DeviceHistoryDialog.tsx`: デバイス履歴ダイアログ
   - `src/hooks/useWebSocketConnection.ts`: WebSocket接続管理
   - `src/hooks/useECHONET.ts`: ECHONETプロトコル状態管理
+  - `src/hooks/useDeviceHistory.ts`: デバイス履歴取得
   - `src/hooks/useAutoReconnect.ts`: 自動再接続機能
   - `src/hooks/useLogNotifications.ts`: ログ通知機能
   - `src/hooks/usePersistedTab.ts`: タブ状態永続化


### PR DESCRIPTION
## Summary

Updates `CLAUDE.md` to document the newly implemented device history feature as part of issue #287 (Testing and documentation wrap-up for history feature).

### Documentation Updates

#### Implemented Features Section
Added "Device History Display" feature with details:
- History button (clock icon) on device cards opens dialog
- Timeline display showing timestamp, property name, value, and origin (operation/notification)
- settableOnly filter toggle for showing only controllable properties vs. all properties
- Reload button for refreshing history data

#### Main Files Section  
Added history-related files to the Web UI main files list:
- `src/components/DeviceHistoryDialog.tsx`: Device history dialog component
- `src/hooks/useDeviceHistory.ts`: Device history data fetching hook

### Related Issues

- Closes #287 (Testing and documentation for history feature)
- Related to #282 (Main history feature issue - all sub-issues complete)
- Documents features from #288, #289, #290, #286

### Testing & Verification

All CI checks passing for the history feature implementation:

**Go (Server/CLI)**:
- ✅ `go fmt ./...` - Pass
- ✅ `go vet ./...` - Pass  
- ✅ `go test ./...` - All tests pass (10 history tests)
- ✅ `go build` - Success

**Web UI**:
- ✅ `npm run lint` - Pass
- ✅ `npm run typecheck` - Pass
- ✅ `npm run test` - 542 tests pass (18 history tests)
- ✅ `npm run build` - Success

### Follow-up Tasks

Follow-up tasks for future improvements have been documented in issue #282, including:
- History persistence (currently in-memory only)
- Long-term statistics
- Advanced search/filtering
- Performance optimization
- Notification integration

## Checklist

- [x] Documentation accurately reflects implemented features
- [x] All test results verified and passing
- [x] Follow-up tasks documented in main issue
- [x] No code changes (documentation only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)