### PR TITLE
feat(web): add hex viewer for raw data in device history dialog

### DIFF
--- a/web/src/components/DeviceHistoryDialog.tsx
+++ b/web/src/components/DeviceHistoryDialog.tsx
@@ -11,9 +11,10 @@ import {
 } from '@/components/ui/alert-dialog';
 import { Button } from '@/components/ui/button';
 import { Switch } from '@/components/ui/switch';
+import { HexViewer } from '@/components/HexViewer';
 import { useDeviceHistory } from '@/hooks/useDeviceHistory';
 import { isJapanese } from '@/libs/languageHelper';
-import { getPropertyName, formatPropertyValue, getPropertyDescriptor } from '@/libs/propertyHelper';
+import { getPropertyName, formatPropertyValue, getPropertyDescriptor, shouldShowHexViewer } from '@/libs/propertyHelper';
 import type { Device, PropertyDescriptionData } from '@/hooks/types';
 import type { WebSocketConnection } from '@/hooks/useWebSocketConnection';
 
@@ -177,6 +178,10 @@ export function DeviceHistoryDialog({
                   entry.value,
                   descriptor
                 );
+                const canShowHexViewer = shouldShowHexViewer(
+                  entry.value,
+                  descriptor
+                );
 
                 return (
                   <div
@@ -190,11 +195,16 @@ export function DeviceHistoryDialog({
                       </span>
                     </div>
                     <div className="flex items-center justify-between gap-2">
-                      <div className="flex items-center gap-2">
+                      <div className="flex items-center gap-2 relative">
                         <span className="text-muted-foreground">
                           {texts.value}:
                         </span>
                         <span className="font-medium">{formattedValue}</span>
+                        <HexViewer
+                          canShowHexViewer={canShowHexViewer}
+                          currentValue={entry.value}
+                          size="sm"
+                        />
                       </div>
                       <span className="text-xs px-2 py-1 rounded bg-muted">
                         {getOriginText(entry.origin)}


### PR DESCRIPTION
## Summary

Add HexViewer component to DeviceHistoryDialog to display raw property data in hexadecimal format, matching the functionality already available in DeviceCard property displays.

## Changes

- **Import HexViewer component**: Added HexViewer and shouldShowHexViewer to DeviceHistoryDialog imports
- **Enhanced value display**: Added hex viewer button to history entry value display area
- **Consistent UX**: Uses compact size (sm) for appropriate styling in dialog context

## Benefits

- Users can now inspect raw binary data directly from the device history view
- Improves debugging and data analysis capabilities
- Provides feature parity with DeviceCard property display

## Testing

### Pre-commit checks
- ✅ Go: `go fmt`, `go vet`, `go test`, `go build` - all passed
- ✅ Web UI: `npm run lint`, `npm run typecheck`, `npm run test` (542 tests), `npm run build` - all passed

### Manual testing
- Open device history dialog for a device with raw data properties
- Verify binary icon button appears next to raw data values
- Click button to view hexadecimal representation
- Verify hex data displays correctly in compact format

## Screenshots

N/A - UI enhancement (adds icon button for raw data inspection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)