### PR TITLE
feat: add device history persistence to file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ devices.json
 devices.json.*
 aliases.json
 groups.json
+history.json
 echonet-list
 echonet-list.exe
 echonet-list.log

--- a/config/config.go
+++ b/config/config.go
@@ -100,6 +100,7 @@ type Config struct {
 		DevicesFile string `toml:"devices_file"`
 		AliasesFile string `toml:"aliases_file"`
 		GroupsFile  string `toml:"groups_file"`
+		HistoryFile string `toml:"history_file"`
 	} `toml:"data_files"`
 }
 
@@ -129,6 +130,7 @@ func NewConfig() *Config {
 	cfg.DataFiles.DevicesFile = ""
 	cfg.DataFiles.AliasesFile = ""
 	cfg.DataFiles.GroupsFile = ""
+	cfg.DataFiles.HistoryFile = "history.json" // Default history file (set to empty string to disable)
 
 	return cfg
 }

--- a/main.go
+++ b/main.go
@@ -143,7 +143,10 @@ func main() {
 			client.NewECHONETListClientProxy(s.GetHandler()),
 			s.GetHandler(),
 			serverStartupTime,
-			server.HistoryOptions{PerDeviceLimit: cfg.History.PerDeviceLimit},
+			server.HistoryOptions{
+				PerDeviceLimit:  cfg.History.PerDeviceLimit,
+				HistoryFilePath: cfg.DataFiles.HistoryFile,
+			},
 		)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "WebSocketサーバーの作成に失敗しました: %v\n", err)

--- a/server/device_history_store_test.go
+++ b/server/device_history_store_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"fmt"
 	"net"
+	"os"
 	"testing"
 	"time"
 
@@ -256,4 +257,405 @@ func testDevice(id int) handler.IPAndEOJ {
 		IP:  ip,
 		EOJ: eoj,
 	}
+}
+
+func TestMemoryDeviceHistoryStore_SaveToFile(t *testing.T) {
+	store := newMemoryDeviceHistoryStore(HistoryOptions{PerDeviceLimit: 10})
+	device1 := testDevice(1)
+	device2 := testDevice(2)
+	now := time.Now().UTC()
+
+	// Add some test data
+	store.Record(DeviceHistoryEntry{
+		Timestamp: now,
+		Device:    device1,
+		EPC:       echonet_lite.EPCType(0x80),
+		Value:     protocol.PropertyData{String: "on"},
+		Origin:    HistoryOriginSet,
+		Settable:  true,
+	})
+	store.Record(DeviceHistoryEntry{
+		Timestamp: now.Add(1 * time.Minute),
+		Device:    device2,
+		EPC:       echonet_lite.EPCType(0xB0),
+		Value:     protocol.PropertyData{Number: intPtr(25)},
+		Origin:    HistoryOriginNotification,
+		Settable:  false,
+	})
+
+	// Save to temporary file
+	tmpFile := t.TempDir() + "/history_test.json"
+	err := store.SaveToFile(tmpFile)
+	if err != nil {
+		t.Fatalf("SaveToFile failed: %v", err)
+	}
+
+	// Verify file exists and is valid JSON
+	data, err := readTestFile(tmpFile)
+	if err != nil {
+		t.Fatalf("failed to read saved file: %v", err)
+	}
+
+	if len(data) == 0 {
+		t.Fatal("saved file is empty")
+	}
+
+	// Basic JSON structure check
+	if !containsString(data, "\"version\"") || !containsString(data, "\"data\"") {
+		t.Error("saved file does not contain expected JSON structure")
+	}
+}
+
+func TestMemoryDeviceHistoryStore_LoadFromFile_BasicLoad(t *testing.T) {
+	// Create and populate store
+	store1 := newMemoryDeviceHistoryStore(HistoryOptions{PerDeviceLimit: 10})
+	device := testDevice(1)
+	now := time.Now().UTC()
+
+	store1.Record(DeviceHistoryEntry{
+		Timestamp: now,
+		Device:    device,
+		EPC:       echonet_lite.EPCType(0x80),
+		Value:     protocol.PropertyData{String: "test-value"},
+		Origin:    HistoryOriginSet,
+		Settable:  true,
+	})
+
+	// Save to file
+	tmpFile := t.TempDir() + "/history_load_test.json"
+	if err := store1.SaveToFile(tmpFile); err != nil {
+		t.Fatalf("SaveToFile failed: %v", err)
+	}
+
+	// Load into new store
+	store2 := newMemoryDeviceHistoryStore(HistoryOptions{PerDeviceLimit: 10})
+	filter := HistoryLoadFilter{
+		Since:          24 * time.Hour, // Load everything within 24 hours
+		PerDeviceLimit: 100,
+	}
+	if err := store2.LoadFromFile(tmpFile, filter); err != nil {
+		t.Fatalf("LoadFromFile failed: %v", err)
+	}
+
+	// Verify loaded data
+	entries := store2.Query(device, HistoryQuery{})
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry after load, got %d", len(entries))
+	}
+
+	if entries[0].Value.String != "test-value" {
+		t.Errorf("expected value 'test-value', got '%s'", entries[0].Value.String)
+	}
+	if entries[0].EPC != echonet_lite.EPCType(0x80) {
+		t.Errorf("expected EPC 0x80, got 0x%02X", entries[0].EPC)
+	}
+	if entries[0].Origin != HistoryOriginSet {
+		t.Errorf("expected origin 'set', got '%s'", entries[0].Origin)
+	}
+}
+
+func TestMemoryDeviceHistoryStore_LoadFromFile_TimeFilter(t *testing.T) {
+	store1 := newMemoryDeviceHistoryStore(HistoryOptions{PerDeviceLimit: 10})
+	device := testDevice(1)
+	now := time.Now().UTC()
+
+	// Add entries at different times
+	entries := []struct {
+		offset time.Duration
+		value  string
+	}{
+		{-10 * 24 * time.Hour, "very-old"}, // 10 days ago
+		{-5 * 24 * time.Hour, "old"},       // 5 days ago
+		{-2 * 24 * time.Hour, "recent"},    // 2 days ago
+		{-1 * time.Hour, "very-recent"},    // 1 hour ago
+	}
+
+	for i, entry := range entries {
+		store1.Record(DeviceHistoryEntry{
+			Timestamp: now.Add(entry.offset),
+			Device:    device,
+			EPC:       echonet_lite.EPCType(0x80 + byte(i)),
+			Value:     protocol.PropertyData{String: entry.value},
+			Origin:    HistoryOriginNotification,
+			Settable:  true,
+		})
+	}
+
+	// Save to file
+	tmpFile := t.TempDir() + "/history_time_filter_test.json"
+	if err := store1.SaveToFile(tmpFile); err != nil {
+		t.Fatalf("SaveToFile failed: %v", err)
+	}
+
+	// Load with time filter (only last 3 days)
+	store2 := newMemoryDeviceHistoryStore(HistoryOptions{PerDeviceLimit: 10})
+	filter := HistoryLoadFilter{
+		Since:          3 * 24 * time.Hour, // Last 3 days
+		PerDeviceLimit: 100,
+	}
+	if err := store2.LoadFromFile(tmpFile, filter); err != nil {
+		t.Fatalf("LoadFromFile failed: %v", err)
+	}
+
+	// Verify only recent entries were loaded
+	loadedEntries := store2.Query(device, HistoryQuery{})
+	if len(loadedEntries) != 2 {
+		t.Fatalf("expected 2 entries (within 3 days), got %d", len(loadedEntries))
+	}
+
+	// Check that very-old and old entries were filtered out
+	for _, entry := range loadedEntries {
+		if entry.Value.String == "very-old" || entry.Value.String == "old" {
+			t.Errorf("time filter failed: entry '%s' should have been filtered out", entry.Value.String)
+		}
+	}
+}
+
+func TestMemoryDeviceHistoryStore_LoadFromFile_CountFilter(t *testing.T) {
+	store1 := newMemoryDeviceHistoryStore(HistoryOptions{PerDeviceLimit: 100})
+	device := testDevice(1)
+	now := time.Now().UTC()
+
+	// Add 10 entries
+	for i := 0; i < 10; i++ {
+		store1.Record(DeviceHistoryEntry{
+			Timestamp: now.Add(time.Duration(i) * time.Minute),
+			Device:    device,
+			EPC:       echonet_lite.EPCType(0x80),
+			Value:     protocol.PropertyData{String: fmt.Sprintf("value-%d", i)},
+			Origin:    HistoryOriginNotification,
+			Settable:  true,
+		})
+	}
+
+	// Save to file
+	tmpFile := t.TempDir() + "/history_count_filter_test.json"
+	if err := store1.SaveToFile(tmpFile); err != nil {
+		t.Fatalf("SaveToFile failed: %v", err)
+	}
+
+	// Load with count filter (only 3 most recent)
+	store2 := newMemoryDeviceHistoryStore(HistoryOptions{PerDeviceLimit: 100})
+	filter := HistoryLoadFilter{
+		Since:          24 * time.Hour, // Load everything within 24 hours
+		PerDeviceLimit: 3,              // But only 3 per device
+	}
+	if err := store2.LoadFromFile(tmpFile, filter); err != nil {
+		t.Fatalf("LoadFromFile failed: %v", err)
+	}
+
+	// Verify only 3 most recent entries were loaded
+	loadedEntries := store2.Query(device, HistoryQuery{})
+	if len(loadedEntries) != 3 {
+		t.Fatalf("expected 3 entries (count limit), got %d", len(loadedEntries))
+	}
+
+	// Should be newest first: value-9, value-8, value-7
+	expectedValues := []string{"value-9", "value-8", "value-7"}
+	for i, expected := range expectedValues {
+		if loadedEntries[i].Value.String != expected {
+			t.Errorf("entry %d: expected '%s', got '%s'", i, expected, loadedEntries[i].Value.String)
+		}
+	}
+}
+
+func TestMemoryDeviceHistoryStore_RoundTrip(t *testing.T) {
+	store1 := newMemoryDeviceHistoryStore(HistoryOptions{PerDeviceLimit: 10})
+	device1 := testDevice(1)
+	device2 := testDevice(2)
+	now := time.Now().UTC()
+
+	// Add diverse data types
+	num25 := 25
+	store1.Record(DeviceHistoryEntry{
+		Timestamp: now,
+		Device:    device1,
+		EPC:       echonet_lite.EPCType(0x80),
+		Value:     protocol.PropertyData{String: "string-value"},
+		Origin:    HistoryOriginSet,
+		Settable:  true,
+	})
+	store1.Record(DeviceHistoryEntry{
+		Timestamp: now.Add(1 * time.Minute),
+		Device:    device1,
+		EPC:       echonet_lite.EPCType(0xB0),
+		Value:     protocol.PropertyData{Number: &num25},
+		Origin:    HistoryOriginNotification,
+		Settable:  false,
+	})
+	store1.Record(DeviceHistoryEntry{
+		Timestamp: now.Add(2 * time.Minute),
+		Device:    device2,
+		EPC:       echonet_lite.EPCType(0xC0),
+		Value:     protocol.PropertyData{EDT: "AQIDBA=="},
+		Origin:    HistoryOriginSet,
+		Settable:  true,
+	})
+
+	// Save
+	tmpFile := t.TempDir() + "/history_roundtrip_test.json"
+	if err := store1.SaveToFile(tmpFile); err != nil {
+		t.Fatalf("SaveToFile failed: %v", err)
+	}
+
+	// Load
+	store2 := newMemoryDeviceHistoryStore(HistoryOptions{PerDeviceLimit: 10})
+	filter := HistoryLoadFilter{
+		Since:          24 * time.Hour,
+		PerDeviceLimit: 100,
+	}
+	if err := store2.LoadFromFile(tmpFile, filter); err != nil {
+		t.Fatalf("LoadFromFile failed: %v", err)
+	}
+
+	// Verify device1 entries
+	entries1 := store2.Query(device1, HistoryQuery{})
+	if len(entries1) != 2 {
+		t.Fatalf("device1: expected 2 entries, got %d", len(entries1))
+	}
+
+	// Verify device2 entries
+	entries2 := store2.Query(device2, HistoryQuery{})
+	if len(entries2) != 1 {
+		t.Fatalf("device2: expected 1 entry, got %d", len(entries2))
+	}
+
+	// Check string value
+	if entries1[1].Value.String != "string-value" {
+		t.Errorf("string value mismatch: expected 'string-value', got '%s'", entries1[1].Value.String)
+	}
+
+	// Check numeric value
+	if entries1[0].Value.Number == nil || *entries1[0].Value.Number != 25 {
+		t.Errorf("numeric value mismatch")
+	}
+
+	// Check EDT value
+	if entries2[0].Value.EDT != "AQIDBA==" {
+		t.Errorf("EDT value mismatch: expected 'AQIDBA==', got '%s'", entries2[0].Value.EDT)
+	}
+}
+
+func TestMemoryDeviceHistoryStore_LoadFromFile_FileNotFound(t *testing.T) {
+	store := newMemoryDeviceHistoryStore(HistoryOptions{PerDeviceLimit: 10})
+	filter := DefaultHistoryLoadFilter()
+
+	// Try to load non-existent file - should not error
+	err := store.LoadFromFile("/nonexistent/path/history.json", filter)
+	if err != nil {
+		t.Errorf("LoadFromFile should not error on non-existent file, got: %v", err)
+	}
+
+	// Store should remain empty
+	device := testDevice(1)
+	entries := store.Query(device, HistoryQuery{})
+	if len(entries) != 0 {
+		t.Errorf("expected empty store after loading non-existent file, got %d entries", len(entries))
+	}
+}
+
+func TestMemoryDeviceHistoryStore_LoadFromFile_InvalidJSON(t *testing.T) {
+	store := newMemoryDeviceHistoryStore(HistoryOptions{PerDeviceLimit: 10})
+	filter := DefaultHistoryLoadFilter()
+
+	// Create file with invalid JSON
+	tmpFile := t.TempDir() + "/invalid.json"
+	if err := writeTestFile(tmpFile, []byte("invalid json content")); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	// Load should fail with error
+	err := store.LoadFromFile(tmpFile, filter)
+	if err == nil {
+		t.Error("LoadFromFile should error on invalid JSON")
+	}
+}
+
+func TestMemoryDeviceHistoryStore_LoadFromFile_EmptyFile(t *testing.T) {
+	store := newMemoryDeviceHistoryStore(HistoryOptions{PerDeviceLimit: 10})
+	filter := DefaultHistoryLoadFilter()
+
+	// Create empty file
+	tmpFile := t.TempDir() + "/empty.json"
+	if err := writeTestFile(tmpFile, []byte("")); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	// Load should fail with error
+	err := store.LoadFromFile(tmpFile, filter)
+	if err == nil {
+		t.Error("LoadFromFile should error on empty file")
+	}
+}
+
+func TestMemoryDeviceHistoryStore_LoadFromFile_MultipleDevices(t *testing.T) {
+	store1 := newMemoryDeviceHistoryStore(HistoryOptions{PerDeviceLimit: 100})
+	now := time.Now().UTC()
+
+	// Add entries for multiple devices
+	for deviceID := 1; deviceID <= 5; deviceID++ {
+		device := testDevice(deviceID)
+		for i := 0; i < 3; i++ {
+			store1.Record(DeviceHistoryEntry{
+				Timestamp: now.Add(time.Duration(i) * time.Minute),
+				Device:    device,
+				EPC:       echonet_lite.EPCType(0x80),
+				Value:     protocol.PropertyData{String: fmt.Sprintf("device%d-value%d", deviceID, i)},
+				Origin:    HistoryOriginNotification,
+				Settable:  true,
+			})
+		}
+	}
+
+	// Save
+	tmpFile := t.TempDir() + "/history_multi_device_test.json"
+	if err := store1.SaveToFile(tmpFile); err != nil {
+		t.Fatalf("SaveToFile failed: %v", err)
+	}
+
+	// Load
+	store2 := newMemoryDeviceHistoryStore(HistoryOptions{PerDeviceLimit: 100})
+	filter := HistoryLoadFilter{
+		Since:          24 * time.Hour,
+		PerDeviceLimit: 100,
+	}
+	if err := store2.LoadFromFile(tmpFile, filter); err != nil {
+		t.Fatalf("LoadFromFile failed: %v", err)
+	}
+
+	// Verify all devices have their entries
+	for deviceID := 1; deviceID <= 5; deviceID++ {
+		device := testDevice(deviceID)
+		entries := store2.Query(device, HistoryQuery{})
+		if len(entries) != 3 {
+			t.Errorf("device %d: expected 3 entries, got %d", deviceID, len(entries))
+		}
+	}
+}
+
+// Helper functions for tests
+
+func readTestFile(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+func writeTestFile(path string, data []byte) error {
+	return os.WriteFile(path, data, 0644)
+}
+
+func containsString(s, substr string) bool {
+	return len(s) > 0 && len(substr) > 0 && len(s) >= len(substr) && findSubstring(s, substr)
+}
+
+func findSubstring(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
 }

--- a/systemd/config.toml.systemd
+++ b/systemd/config.toml.systemd
@@ -39,3 +39,16 @@ enabled = true
 [websocket_client]
 enabled = false
 # addr = "ws://remote-server:8080/ws"
+
+# データファイル設定
+[data_files]
+# デバイス履歴ファイル（デフォルト: history.json）
+# WorkingDirectory が /var/lib/echonet-list のため、
+# 実際のパスは /var/lib/echonet-list/history.json になります
+# 空文字列で履歴の永続化を無効にできます
+history_file = "history.json"
+
+# 他のデータファイルも明示的に指定できます:
+# devices_file = "devices.json"
+# aliases_file = "aliases.json"
+# groups_file = "groups.json"


### PR DESCRIPTION
## 概要

デバイス履歴データの永続化機能を実装しました。終了時に履歴を自動保存し、起動時に自動読み込みを行います。長期的なデータ蓄積を防ぐため、時間ベースと件数ベースのフィルタリングを実装しています。

## 主な変更内容

### コア実装

- **ファイル永続化**: `memoryDeviceHistoryStore` に `SaveToFile` / `LoadFromFile` メソッドを追加
- **JSONシリアライゼーション**: バージョン管理付き（version 1）のJSON形式
- **アトミック書き込み**: 一時ファイル経由の安全な書き込み（temp file + rename）
- **ライフサイクル統合**: WebSocketServerの起動/終了時に自動保存・読み込み

### フィルタリング戦略

読み込み時に以下のフィルタを適用し、データ増加を抑制：

- **時間フィルター**: 直近7日間のエントリのみ読み込み
- **件数フィルター**: デバイスごとに最新100件まで

### 設定

- `config.DataFiles.HistoryFile` に履歴ファイルパスを追加
- **デフォルト**: `"history.json"` （デフォルトで有効）
- **無効化**: 空文字列を設定
- `config.toml` と `systemd/config.toml.systemd` にサンプル設定を追加

### ファイル保存場所

| 環境 | パス |
|------|------|
| 開発環境 | `./history.json` |
| デーモン（systemd） | `/var/lib/echonet-list/history.json` |

## テスト

包括的なテストを追加（10個の新規テストケース）：

- ✅ 基本的な保存・読み込み機能
- ✅ 時間ベースフィルタリング
- ✅ 件数ベースフィルタリング
- ✅ ラウンドトリップデータ整合性
- ✅ エラーケース（無効JSON、ファイル未存在等）
- ✅ 複数デバイス処理

### テスト結果

```
Go tests: ✅ All passed
Web UI tests: ✅ 542 tests passed
Build: ✅ Success
Lint: ✅ No issues
Type check: ✅ No errors
```

## 品質保証

- 全テスト通過（Go + Web UI合計542テスト）
- コードフォーマット・lintチェック済み
- 既存機能への影響なし（後方互換性あり）
- 設定ファイルなしでも動作（デフォルト値設定済み）

## 技術詳細

### JSON形式

```json
{
  "version": 1,
  "data": {
    "192.168.1.100 0130:01": [
      {
        "timestamp": "2025-10-15T12:34:56.789Z",
        "device": { "ip": "192.168.1.100", "eoj": "0130:01" },
        "epc": "0xB0",
        "value": { ... },
        "origin": "set",
        "settable": true
      }
    ]
  }
}
```

### フィルタリングロジック

- ファイル読み込み時に新しいエントリから処理
- タイムスタンプでカットオフ（7日以前を除外）
- デバイスごとに最新100件を保持
- フィルタ後、時系列順に復元

## 動作確認

1. サーバー起動・操作実行
2. サーバー終了（`quit` または Ctrl+C）
3. `history.json` が作成されることを確認
4. サーバー再起動時に履歴が読み込まれることを確認

ログ例：
```
INFO History data loaded successfully filename=history.json totalLoaded=15 totalFiltered=5 deviceCount=3
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>