### PR TITLE
feat(web): enable react-hooks/static-components rule

### DIFF
--- a/web/eslint.config.ts
+++ b/web/eslint.config.ts
@@ -34,7 +34,6 @@ export default tseslint.config(
       'react/prop-types': 'off',
       '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
       // Temporarily disable new strict rules that require large refactoring
-      'react-hooks/static-components': 'off',
       'react-hooks/set-state-in-effect': 'off',
     },
     settings: {

--- a/web/src/components/DeviceIcon.test.tsx
+++ b/web/src/components/DeviceIcon.test.tsx
@@ -10,23 +10,29 @@ vi.mock('@/libs/propertyHelper', () => ({
   isOperationStatusSettable: vi.fn(),
 }));
 
-vi.mock('@/libs/deviceIconHelper', () => ({
-  getDeviceIcon: vi.fn(() => TestIcon),
-  getDeviceIconColor: vi.fn(),
-}));
-
-// Test icon component
+// Test icon component needs to be defined before mock
 function TestIcon({ className }: { className?: string }) {
   return <svg className={className} data-testid="test-icon" />;
 }
 
+vi.mock('@/libs/deviceIconHelper', () => ({
+  DEVICE_CLASS_ICONS: {
+    '0130': TestIcon,
+    '0291': TestIcon,
+    '03B7': TestIcon,
+    '0EF0': TestIcon,
+  },
+  DEFAULT_DEVICE_ICON: TestIcon,
+  getDeviceIcon: vi.fn(() => TestIcon),
+  getDeviceIconColor: vi.fn(),
+}));
+
 import { isDeviceOperational, isDeviceFaulty, isOperationStatusSettable } from '@/libs/propertyHelper';
-import { getDeviceIcon, getDeviceIconColor } from '@/libs/deviceIconHelper';
+import { getDeviceIconColor } from '@/libs/deviceIconHelper';
 
 const mockIsDeviceOperational = isDeviceOperational as ReturnType<typeof vi.fn>;
 const mockIsDeviceFaulty = isDeviceFaulty as ReturnType<typeof vi.fn>;
 const mockIsOperationStatusSettable = isOperationStatusSettable as ReturnType<typeof vi.fn>;
-const mockGetDeviceIcon = getDeviceIcon as ReturnType<typeof vi.fn>;
 const mockGetDeviceIconColor = getDeviceIconColor as ReturnType<typeof vi.fn>;
 
 describe('DeviceIcon', () => {
@@ -43,7 +49,6 @@ describe('DeviceIcon', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mockGetDeviceIcon.mockReturnValue(TestIcon);
     mockIsOperationStatusSettable.mockReturnValue(true); // Default to controllable
   });
 

--- a/web/src/components/DeviceIcon.tsx
+++ b/web/src/components/DeviceIcon.tsx
@@ -1,5 +1,4 @@
-import { useMemo } from 'react';
-import { getDeviceIcon, getDeviceIconColor } from '@/libs/deviceIconHelper';
+import { DEVICE_CLASS_ICONS, DEFAULT_DEVICE_ICON, getDeviceIconColor } from '@/libs/deviceIconHelper';
 import { isDeviceOperational, isDeviceFaulty, isOperationStatusSettable } from '@/libs/propertyHelper';
 import type { Device } from '@/hooks/types';
 
@@ -10,7 +9,7 @@ interface DeviceIconProps {
 }
 
 export function DeviceIcon({ device, classCode, className = '' }: DeviceIconProps) {
-  const Icon = useMemo(() => getDeviceIcon(classCode), [classCode]);
+  const IconComponent = DEVICE_CLASS_ICONS[classCode] ?? DEFAULT_DEVICE_ICON;
   const isOperational = isDeviceOperational(device);
   const isFaulty = isDeviceFaulty(device);
   const isControllable = isOperationStatusSettable(device);
@@ -28,7 +27,7 @@ export function DeviceIcon({ device, classCode, className = '' }: DeviceIconProp
   
   return (
     <div title={`${deviceTypeName} - ${statusText}`}>
-      <Icon className={`w-4 h-4 ${iconColor} ${className}`} />
+      <IconComponent className={`w-4 h-4 ${iconColor} ${className}`} />
     </div>
   );
 }

--- a/web/src/components/PropertyRow.test.tsx
+++ b/web/src/components/PropertyRow.test.tsx
@@ -24,21 +24,32 @@ vi.mock('@/libs/propertyHelper', () => ({
 }));
 
 // Mock sensor property helper
-vi.mock('@/libs/sensorPropertyHelper', () => ({
-  isSensorProperty: (_classCode: string, epc: string) => ['BB', 'BA', 'BE'].includes(epc),
-  getSensorIcon: (_classCode: string, epc: string) => {
-    const iconMap: Record<string, any> = {
-      'BB': ({ className }: { className?: string }) => 
-        <svg data-testid="thermometer-icon" className={className}>Thermometer</svg>,
-      'BA': ({ className }: { className?: string }) => 
-        <svg data-testid="droplets-icon" className={className}>Droplets</svg>,
-      'BE': ({ className }: { className?: string }) => 
-        <svg data-testid="cloudsun-icon" className={className}>CloudSun</svg>
-    };
-    return iconMap[epc];
-  },
-  getSensorIconColor: (_classCode: string, _epc: string, _value: any) => 'text-muted-foreground'
-}));
+vi.mock('@/libs/sensorPropertyHelper', () => {
+  const ThermometerIcon = ({ className }: { className?: string }) =>
+    <svg data-testid="thermometer-icon" className={className}>Thermometer</svg>;
+  const DropletsIcon = ({ className }: { className?: string }) =>
+    <svg data-testid="droplets-icon" className={className}>Droplets</svg>;
+  const CloudSunIcon = ({ className }: { className?: string }) =>
+    <svg data-testid="cloudsun-icon" className={className}>CloudSun</svg>;
+
+  return {
+    isSensorProperty: (_classCode: string, epc: string) => ['BB', 'BA', 'BE'].includes(epc),
+    SENSOR_PROPERTY_ICONS: {
+      '0130:BB': ThermometerIcon,
+      '0130:BA': DropletsIcon,
+      '0130:BE': CloudSunIcon
+    },
+    getSensorIcon: (_classCode: string, epc: string) => {
+      const iconMap: Record<string, any> = {
+        'BB': ThermometerIcon,
+        'BA': DropletsIcon,
+        'BE': CloudSunIcon
+      };
+      return iconMap[epc];
+    },
+    getSensorIconColor: (_classCode: string, _epc: string, _value: any) => 'text-muted-foreground'
+  };
+});
 
 describe('PropertyRow', () => {
   const mockDevice: Device = {

--- a/web/src/components/PropertyRow.tsx
+++ b/web/src/components/PropertyRow.tsx
@@ -1,8 +1,7 @@
-import { useMemo } from 'react';
 import { PropertyEditor } from './PropertyEditor';
 import { PropertyDisplay } from './PropertyDisplay';
 import { getPropertyName, getPropertyDescriptor, isPropertySettable } from '@/libs/propertyHelper';
-import { isSensorProperty, getSensorIcon, getSensorIconColor } from '@/libs/sensorPropertyHelper';
+import { isSensorProperty, SENSOR_PROPERTY_ICONS, getSensorIconColor } from '@/libs/sensorPropertyHelper';
 import { getCurrentLocale } from '@/libs/languageHelper';
 import type { Device, PropertyValue, PropertyDescriptionData, DeviceAlias } from '@/hooks/types';
 
@@ -47,14 +46,15 @@ export function PropertyRow({
 
   // Check if this is a sensor property for special compact display
   const isSensor = isSensorProperty(classCode, epc);
-  const SensorIcon = useMemo(() => getSensorIcon(classCode, epc), [classCode, epc]);
+  const sensorKey = `${classCode}:${epc}`;
+  const SensorIconComponent = SENSOR_PROPERTY_ICONS[sensorKey];
   const sensorIconColor = getSensorIconColor(classCode, epc, value);
 
-  if (isCompact && isSensor && SensorIcon) {
+  if (isCompact && isSensor && SensorIconComponent) {
     // Sensor properties in compact mode: icon + value only
     return (
       <div className="inline-flex items-center gap-1 text-xs mr-3 mb-1" title={propertyName}>
-        <SensorIcon className={`h-3 w-3 ${sensorIconColor}`} />
+        <SensorIconComponent className={`h-3 w-3 ${sensorIconColor}`} />
         <div>
           {isSettable ? (
             <PropertyEditor

--- a/web/src/libs/deviceIconHelper.ts
+++ b/web/src/libs/deviceIconHelper.ts
@@ -12,6 +12,11 @@ import {
 } from 'lucide-react';
 
 /**
+ * Default icon for unknown device types
+ */
+export const DEFAULT_DEVICE_ICON = CircleHelp;
+
+/**
  * Mapping of ECHONET Lite device class codes to Lucide icons
  */
 export const DEVICE_CLASS_ICONS: Record<string, LucideIcon> = {

--- a/web/src/libs/sensorPropertyHelper.ts
+++ b/web/src/libs/sensorPropertyHelper.ts
@@ -10,7 +10,7 @@ import {
 import type { PropertyValue } from '@/hooks/types';
 
 // Sensor property EPCs and their corresponding icons using classCode:EPC format
-const SENSOR_PROPERTY_ICONS: Record<string, LucideIcon> = {
+export const SENSOR_PROPERTY_ICONS: Record<string, LucideIcon> = {
   // Air Conditioner (0130) sensors
   '0130:BB': Thermometer,  // Room temperature
   '0130:BE': CloudSun,     // Outside temperature


### PR DESCRIPTION
## Summary

Enable the `react-hooks/static-components` ESLint rule by fixing dynamic component creation violations in the Web UI. This improves React component stability by preventing components from being recreated on every render.

### Key Changes

- 🔧 **DeviceIcon & PropertyRow**: Changed from calling helper functions that return components to directly accessing static component maps
- 📦 **Helper Libraries**: Exported icon maps (`DEVICE_CLASS_ICONS`, `SENSOR_PROPERTY_ICONS`) and default icon
- ✅ **ESLint Config**: Enabled `react-hooks/static-components` rule
- 🧪 **Tests**: Updated mocks to include newly exported constants

### Technical Details

**Before:**
```tsx
const Icon = useMemo(() => getDeviceIcon(classCode), [classCode]);
return <Icon />;
```

**After:**
```tsx
const IconComponent = DEVICE_CLASS_ICONS[classCode] ?? DEFAULT_DEVICE_ICON;
return <IconComponent />;
```

This pattern satisfies the new stricter ESLint rule by avoiding function calls that return components during render, while maintaining the same functionality.

## Test Results

### Go Server
- ✅ Format: `go fmt ./...`
- ✅ Vet: `go vet ./...`
- ✅ Tests: All packages pass
- ✅ Build: Successful

### Web UI  
- ✅ Lint: No errors (including new rule)
- ✅ TypeCheck: No errors
- ✅ Tests: **542/542 passed**
- ✅ Build: Successful (bundle size unchanged)

## Related

This work builds on PR #305 which upgraded `eslint-plugin-react-hooks` to v7.0.0. At that time, the `react-hooks/static-components` rule was temporarily disabled to allow gradual adoption. This PR enables that rule by implementing the required fixes.

The other disabled rule `react-hooks/set-state-in-effect` remains disabled as it would require a larger architectural refactor of the notification system.

🤖 Generated with [Claude Code](https://claude.com/claude-code)