### PR TITLE
feat(web): enable react-hooks/set-state-in-effect rule

### DIFF
--- a/web/eslint.config.ts
+++ b/web/eslint.config.ts
@@ -33,8 +33,6 @@ export default tseslint.config(
       'react-refresh/only-export-components': 'off',
       'react/prop-types': 'off',
       '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
-      // Temporarily disable new strict rules that require large refactoring
-      'react-hooks/set-state-in-effect': 'off',
     },
     settings: {
       react: {

--- a/web/src/hooks/useLogNotifications.ts
+++ b/web/src/hooks/useLogNotifications.ts
@@ -12,20 +12,12 @@ export interface LogEntry {
 }
 
 interface LogNotificationsProps {
-  notification?: LogNotification;
-  deviceOnlineNotification?: DeviceOnline;
-  deviceOfflineNotification?: DeviceOffline;
-  localErrorNotification?: LogEntry;
   resolveAlias?: (ip: string, eoj: string) => string | null;
   maxLogs?: number;
   onLogsChange?: (logs: LogEntry[], unreadCount: number) => void;
 }
 
-export function useLogNotifications({ 
-  notification, 
-  deviceOnlineNotification,
-  deviceOfflineNotification,
-  localErrorNotification,
+export function useLogNotifications({
   resolveAlias,
   maxLogs = 50,
   onLogsChange
@@ -87,7 +79,6 @@ export function useLogNotifications({
     };
   }, [formatDeviceIdentification]);
 
-  // Helper function to add log entry to the list
   const addLogEntry = useCallback((newLog: LogEntry) => {
     setLogs(prev => {
       const updated = [newLog, ...prev];
@@ -95,41 +86,25 @@ export function useLogNotifications({
     });
   }, [maxLogs]);
 
-  // Add new log entry when notification is received
-  useEffect(() => {
-    if (!notification) return;
-
+  const handleLogNotification = useCallback((incomingNotification: LogNotification) => {
     const newLog: LogEntry = {
       id: generateLogEntryId('log'),
-      ...notification.payload,
+      ...incomingNotification.payload,
       isRead: false
     };
 
     addLogEntry(newLog);
-  }, [notification, addLogEntry]);
+  }, [addLogEntry]);
 
-  // Add device online notification
-  useEffect(() => {
-    if (!deviceOnlineNotification) return;
-
-    const newLog = createDeviceStatusLogEntry('online', deviceOnlineNotification);
+  const handleDeviceOnlineNotification = useCallback((incomingNotification: DeviceOnline) => {
+    const newLog = createDeviceStatusLogEntry('online', incomingNotification);
     addLogEntry(newLog);
-  }, [deviceOnlineNotification, addLogEntry, createDeviceStatusLogEntry]);
+  }, [addLogEntry, createDeviceStatusLogEntry]);
 
-  // Add device offline notification
-  useEffect(() => {
-    if (!deviceOfflineNotification) return;
-
-    const newLog = createDeviceStatusLogEntry('offline', deviceOfflineNotification);
+  const handleDeviceOfflineNotification = useCallback((incomingNotification: DeviceOffline) => {
+    const newLog = createDeviceStatusLogEntry('offline', incomingNotification);
     addLogEntry(newLog);
-  }, [deviceOfflineNotification, addLogEntry, createDeviceStatusLogEntry]);
-
-  // Handle local error notifications
-  useEffect(() => {
-    if (localErrorNotification) {
-      addLogEntry(localErrorNotification);
-    }
-  }, [localErrorNotification, addLogEntry]);
+  }, [addLogEntry, createDeviceStatusLogEntry]);
 
   // Notify parent component about logs changes
   useEffect(() => {
@@ -155,6 +130,10 @@ export function useLogNotifications({
   // Return functions for parent component to use
   return {
     logs,
+    addLogEntry,
+    handleLogNotification,
+    handleDeviceOnlineNotification,
+    handleDeviceOfflineNotification,
     markAllAsRead,
     clearAllLogs,
     clearByCategory


### PR DESCRIPTION
## Summary

This PR enables the `react-hooks/set-state-in-effect` ESLint rule from eslint-plugin-react-hooks v7.0.0 by refactoring the `useLogNotifications` hook to follow React best practices.

## Changes

### Core Refactoring

**useLogNotifications Hook** (`web/src/hooks/useLogNotifications.ts`):
- ❌ **Removed**: 4 `useEffect` hooks that called `setState` synchronously
- ✅ **Added**: Explicit callback handlers (`handleLogNotification`, `handleDeviceOnlineNotification`, `handleDeviceOfflineNotification`)
- ✅ **Changed**: From reactive props pattern to imperative callback pattern

**App.tsx**:
- Updated to call log handler methods directly from WebSocket message callback
- Removed intermediate state variables for notifications
- Simplified data flow with direct method invocation

**Tests** (`web/src/hooks/useLogNotifications.test.ts`):
- Refactored from prop-based testing to callback-based testing
- Added helper functions for creating test notifications
- All 15 tests passing with improved clarity

**ESLint Config** (`web/eslint.config.ts`):
- Removed temporary disable comment for `react-hooks/set-state-in-effect`

## Benefits

1. **Compliant with ESLint v7.0.0**: Fixes all `react-hooks/set-state-in-effect` violations
2. **More explicit data flow**: Parent components now explicitly control when logs are added
3. **Better React patterns**: Avoids cascading renders from effects
4. **Improved testability**: Direct method calls are easier to test than effect triggers

## Test Results

✅ **Go**: All tests passing
- `go fmt ./...` ✓
- `go vet ./...` ✓
- `go test ./...` ✓
- `go build` ✓

✅ **Web UI**: All checks passing
- `npm run lint` ✓ (no ESLint errors)
- `npm run typecheck` ✓
- `npm run test` ✓ (542/542 tests passing)
- `npm run build` ✓

## Migration Pattern

**Before** (props + useEffect):
```typescript
useLogNotifications({ 
  notification: latestNotification,
  // ... other notification props
})

// In parent:
setLatestNotification(message);
```

**After** (callbacks):
```typescript
const logManager = useLogNotifications({});

// In parent:
logManager.handleLogNotification(message);
```

This pattern is more aligned with React's philosophy of explicit, top-down data flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)