### PR TITLE
feat(web): change default history filter to show all properties

### DIFF
--- a/web/src/components/DeviceHistoryDialog.test.tsx
+++ b/web/src/components/DeviceHistoryDialog.test.tsx
@@ -225,20 +225,20 @@ describe('DeviceHistoryDialog', () => {
 
     const toggle = screen.getByRole('switch');
     expect(toggle).toBeInTheDocument();
-    expect(toggle).toHaveAttribute('aria-checked', 'true');
+    expect(toggle).toHaveAttribute('aria-checked', 'false');
 
     await user.click(toggle);
 
-    // After clicking, the toggle should be unchecked
+    // After clicking, the toggle should be checked
     await waitFor(() => {
-      expect(toggle).toHaveAttribute('aria-checked', 'false');
+      expect(toggle).toHaveAttribute('aria-checked', 'true');
     });
 
-    // The component should call useDeviceHistory with settableOnly=false
+    // The component should call useDeviceHistory with settableOnly=true
     // (This will trigger a re-render and new hook call)
     expect(useDeviceHistory).toHaveBeenLastCalledWith(
       expect.objectContaining({
-        settableOnly: false,
+        settableOnly: true,
       })
     );
   });

--- a/web/src/components/DeviceHistoryDialog.tsx
+++ b/web/src/components/DeviceHistoryDialog.tsx
@@ -56,7 +56,7 @@ export function DeviceHistoryDialog({
   classCode,
   isConnected,
 }: DeviceHistoryDialogProps) {
-  const [settableOnly, setSettableOnly] = useState(true);
+  const [settableOnly, setSettableOnly] = useState(false);
   const deviceTarget = `${device.ip} ${device.eoj}`;
 
   const { entries, isLoading, error, refetch } = useDeviceHistory({


### PR DESCRIPTION
## Summary

Changed the default behavior of the device history dialog to show all properties (both settable and notification-only) by default, instead of showing only settable properties.

### Changes

- Modified `DeviceHistoryDialog.tsx` to set `settableOnly` default value from `true` to `false`
- Updated corresponding test case in `DeviceHistoryDialog.test.tsx` to reflect the new default behavior

### Test Plan

- ✅ All Go checks passed (fmt, vet, test, build)
- ✅ All Web UI checks passed (lint, typecheck, test, build)
- ✅ All 542 tests passed

### User Impact

Users will now see all property changes (both settable and notification-only) by default when opening the device history dialog. They can still toggle the filter to show only settable properties if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)