### PR TITLE
chore(deps): implement GitHub Actions hash pinning and Dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
     schedule:
       interval: "weekly" # Check for updates once a week
     open-pull-requests-limit: 10 # Limit number of open PRs
+    cooldown:
+      default-days: 7
     labels:
       - "dependencies"
       - "go"
@@ -20,6 +22,8 @@ updates:
     schedule:
       interval: "weekly" # Check for updates once a week
     open-pull-requests-limit: 5 # Limit number of open PRs
+    cooldown:
+      default-days: 7
     labels:
       - "dependencies"
       - "github-actions"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,9 @@ jobs:
       docs: ${{ steps.filter.outputs.docs }}
       scripts: ${{ steps.filter.outputs.scripts }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: filter
         with:
           base: main
@@ -64,15 +64,15 @@ jobs:
     if: needs.changes.outputs.server == 'true'
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
           go-version: "1.24"
 
       - name: Cache Go modules
-        uses: actions/cache@v4
+        uses: actions/cache@0c907a75c2c80ebcb7f088228285e798b750cf8f # v4.2.1
         with:
           path: |
             ~/.cache/go-build
@@ -99,7 +99,7 @@ jobs:
         run: go test -v -race -timeout=2m -coverprofile=coverage.out ./...
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@af09b5e394c93991b95a5e7646aeb90c1917f78f # v5.5.1
         with:
           file: ./coverage.out
           flags: go-server
@@ -116,10 +116,10 @@ jobs:
         working-directory: ./web
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: "20"
           cache: "npm"
@@ -141,7 +141,7 @@ jobs:
         run: npm run build
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@af09b5e394c93991b95a5e7646aeb90c1917f78f # v5.5.1
         with:
           file: ./web/coverage/lcov.info
           flags: web-ui
@@ -154,10 +154,10 @@ jobs:
     if: needs.changes.outputs.scripts == 'true'
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Run shellcheck
-        uses: ludeeus/action-shellcheck@2.0.0
+        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # 2.0.0
         with:
           scandir: './script'
           format: gcc
@@ -178,15 +178,15 @@ jobs:
       !contains(needs.*.result, 'cancelled')
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
           go-version: "1.24"
 
       - name: Cache Go modules
-        uses: actions/cache@v4
+        uses: actions/cache@0c907a75c2c80ebcb7f088228285e798b750cf8f # v4.2.1
         with:
           path: |
             ~/.cache/go-build
@@ -196,7 +196,7 @@ jobs:
             ${{ runner.os }}-go-v2-
 
       - name: Set up Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: "20"
           cache: "npm"


### PR DESCRIPTION
## Summary

This PR implements two security improvements for our dependency management:

1. **GitHub Actions Hash Pinning**: GitHub Actions dependencies (except claude-code-action) now use commit hashes instead of version tags
2. **Dependabot Cooldown Period**: Added 7-day cooldown for gomod and github-actions ecosystems

## Security Improvements

### 1. GitHub Actions Hash Pinning

**What changed:**
- Most action references in CI workflows now use commit hashes with version comments
- Format: `action@commithash # vX.Y.Z`

**Updated Actions:**
| Action | Before | After |
|--------|---------|-------|
| actions/checkout | `@v5` | `@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0` |
| dorny/paths-filter | `@v3` | `@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2` |
| actions/setup-go | `@v6` | `@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0` |
| actions/cache | `@v4` | `@0c907a75c2c80ebcb7f088228285e798b750cf8f # v4.2.1` |
| codecov/codecov-action | `@v5` | `@af09b5e394c93991b95a5e7646aeb90c1917f78f # v5.5.1` |
| actions/setup-node | `@v5` | `@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0` |
| ludeeus/action-shellcheck | `@2.0.0` | `@00cae500b08a931fb5698e11e79bfbd38e612a38 # 2.0.0` |

**Note:** `anthropics/claude-code-action` remains at `@beta` and will be updated separately when the action is reinstalled.

**Why this matters:**
- **Prevents tag hijacking**: Git tags can be moved to point to different commits, but commit hashes are immutable
- **Supply chain security**: Ensures we always use the exact code version we've reviewed
- **Reproducible builds**: Guarantees consistent behavior across all CI runs

### 2. Dependabot Cooldown Period

**What changed:**
Added `cooldown: default-days: 7` to:
- `gomod` ecosystem
- `github-actions` ecosystem

(npm already had this configured)

**Why this matters:**
- **Community validation time**: Allows 7 days for the community to discover and report issues with new versions
- **Vulnerability window reduction**: Newly released versions may contain undiscovered vulnerabilities
- **Update rate control**: Prevents rapid successive updates that could introduce instability

## Test Plan

- [x] Go checks passed (fmt, vet, test, build)
- [x] Web UI checks passed (lint, typecheck, test, build)
- [x] All existing tests pass
- [x] Workflows use correct hash format with version comments
- [x] Claude-code-action workflows remain unchanged for future update

## Security Benefits

This PR enhances our security posture by:

1. **Immutable References**: Using commit hashes prevents malicious actors from hijacking version tags
2. **Consistent Security Policy**: All ecosystems now have cooldown periods for safer updates
3. **Transparency**: Version comments make it easy to identify and update action versions
4. **Defense in Depth**: Multiple layers of protection against supply chain attacks

## Related Documentation

- [GitHub Actions Security Hardening](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)
- [Dependabot Cooldown](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#cooldown)

🤖 Generated with [Claude Code](https://claude.com/claude-code)