### PR TITLE
refactor(web): simplify device history auto-refetch mechanism

### DIFF
--- a/web/src/components/DeviceHistoryDialog.tsx
+++ b/web/src/components/DeviceHistoryDialog.tsx
@@ -66,13 +66,6 @@ export function DeviceHistoryDialog({
     settableOnly,
   });
 
-  // Refetch history when settableOnly changes
-  const handleSettableOnlyChange = (checked: boolean) => {
-    setSettableOnly(checked);
-    // Refs are updated synchronously in useDeviceHistory, so we can refetch immediately
-    refetch();
-  };
-
   const messages: Record<'en' | 'ja', DialogMessages> = {
     en: {
       title: 'Device History',
@@ -183,7 +176,7 @@ export function DeviceHistoryDialog({
           <div className="flex items-center gap-2">
             <Switch
               checked={settableOnly}
-              onCheckedChange={handleSettableOnlyChange}
+              onCheckedChange={setSettableOnly}
               disabled={isLoading || !isConnected}
             />
             <label className="text-sm">{texts.settableOnlyLabel}</label>

--- a/web/src/hooks/useDeviceHistory.ts
+++ b/web/src/hooks/useDeviceHistory.ts
@@ -29,18 +29,7 @@ export function useDeviceHistory({
   const [error, setError] = useState<Error | null>(null);
   const requestIdRef = useRef(0);
 
-  // Store current parameters in refs to avoid recreating fetchHistory unnecessarily
-  const settableOnlyRef = useRef(settableOnly);
-  const limitRef = useRef(limit);
-  const sinceRef = useRef(since);
-
-  // Update refs when parameters change
-  settableOnlyRef.current = settableOnly;
-  limitRef.current = limit;
-  sinceRef.current = since;
-
-  // Extract sendMessage to narrow dependency and avoid refetch on connection object reference changes
-  const sendMessage = connection.sendMessage;
+  const { sendMessage } = connection;
 
   const fetchHistory = useCallback(async () => {
     setIsLoading(true);
@@ -56,12 +45,12 @@ export function useDeviceHistory({
         settableOnly: boolean;
       } = {
         target,
-        limit: limitRef.current,
-        settableOnly: settableOnlyRef.current,
+        limit,
+        settableOnly,
       };
 
-      if (sinceRef.current) {
-        payload.since = sinceRef.current;
+      if (since) {
+        payload.since = since;
       }
 
       const response = await sendMessage({
@@ -77,7 +66,7 @@ export function useDeviceHistory({
     } finally {
       setIsLoading(false);
     }
-  }, [sendMessage, target]);
+  }, [sendMessage, target, limit, since, settableOnly]);
 
   useEffect(() => {
     fetchHistory();


### PR DESCRIPTION
## Summary

This PR simplifies the `useDeviceHistory` hook by removing the ref-based parameter tracking pattern and using standard React dependency tracking instead. This enables automatic refetching when parameters change, providing a more intuitive and React-idiomatic implementation.

### Changes Made

- **Removed ref-based parameter tracking**: Eliminated `settableOnlyRef`, `limitRef`, and `sinceRef` in favor of direct parameter usage
- **Updated dependency array**: Added `limit`, `since`, and `settableOnly` to `fetchHistory`'s dependency array
- **Enabled automatic refetch**: Parameter changes now automatically trigger refetch without manual intervention
- **Simplified component logic**: Removed `handleSettableOnlyChange` wrapper in `DeviceHistoryDialog`, using `setSettableOnly` directly

### Benefits

- **Better UX**: Changing the "Settable Only" filter now automatically refreshes the history
- **More predictable**: Aligns with standard React patterns and developer expectations
- **Simpler code**: Reduced complexity by removing the ref tracking pattern
- **Maintainable**: Easier to understand and modify in the future

### Testing

- ✅ All Go tests passing (`go test ./...`)
- ✅ All Web UI tests passing (548 tests)
- ✅ Type checking passed (`npm run typecheck`)
- ✅ Linting passed (`npm run lint`)
- ✅ Build successful

Updated test expectations to verify automatic refetch behavior when `settableOnly` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)