### PR TITLE
fix(build): prevent package-lock.json conflicts in auto-update

### DIFF
--- a/script/build.sh
+++ b/script/build.sh
@@ -43,7 +43,7 @@ fi
 if [[ "$TARGET" == "web" || "$TARGET" == "web-ui" || "$TARGET" == "all" ]]; then
     echo -e "\n${GREEN}Building Web UI...${NC}"
     cd web
-    npm install
+    npm install --no-save
     npm run build
     echo -e "Web UI bundle: ${PROJECT_ROOT}/web/bundle/"
 fi


### PR DESCRIPTION
## Summary

- Changed `npm install` to `npm install --no-save` in `script/build.sh` to prevent package-lock.json modifications during auto-update process

## Problem

- `auto-update.sh` frequently encountered git conflicts with package-lock.json
- Dependabot updates package-lock.json using npm 10 (without `peer` field)
- Local builds with npm 11 automatically add `peer` field to package-lock.json
- This caused conflicts during `git pull` in auto-update workflow

## Solution

- Use `npm install --no-save` flag to install dependencies without modifying package.json or package-lock.json
- Faster than `npm ci` as it reuses existing node_modules
- Prevents package-lock.json conflicts while maintaining dependency installation

## Test Plan

✅ All checks passed:
- Go: `go fmt`, `go vet`, `go test`, `go build` - all successful
- Web UI: `npm run lint`, `npm run typecheck`, `npm run test`, `npm run build` - all successful (551 tests passed)

## Verification

The change was tested to ensure:
- Dependencies are still correctly installed
- package-lock.json is not modified during build
- Build process completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)