### PR TITLE
feat(script): optimize Web UI update to eliminate downtime

### DIFF
--- a/script/auto-update.sh
+++ b/script/auto-update.sh
@@ -133,8 +133,13 @@ else
         exit 1
     }
 
-    # リモートとの差分をチェック（追跡中のブランチを使用）
-    REMOTE_COMMIT=$(git rev-parse '@{u}' 2>/dev/null || git rev-parse origin/HEAD 2>/dev/null || git rev-parse origin/main 2>/dev/null || git rev-parse origin/master 2>/dev/null || echo "")
+    # リモートとの差分をチェック（複数の候補を効率的に検索）
+    REMOTE_COMMIT=""
+    for ref in '@{u}' 'origin/HEAD' 'origin/main' 'origin/master'; do
+        if REMOTE_COMMIT=$(git rev-parse "$ref" 2>/dev/null); then
+            break
+        fi
+    done
 
     if [[ -z "$REMOTE_COMMIT" ]]; then
         print_error "リモートブランチが見つかりません"


### PR DESCRIPTION
## Summary

Optimize the auto-update script to eliminate downtime when updating only Web UI files. The server dynamically reads static files using `http.FileServer`, so Web UI updates don't require a server restart.

## Changes

### 1. `update.sh` - Add `--web-only` mode
- **New option**: `--web-only` flag for Web UI-only updates
- **Behavior**: Copies Web UI files to `/usr/local/share/echonet-list/web/` without stopping the server
- **Zero downtime**: Server continues running and serves new files immediately
- **Full backup**: Always backs up both server binary and Web UI files (for version consistency)
- **Rollback support**: Clear instructions provided for easy rollback if needed

### 2. `auto-update.sh` - Smart update detection
- **Change detection**: Analyzes git diff to determine what changed
  - Go files only → Full update with server restart
  - Web UI files only → `update.sh --web-only` (no restart)
  - Both → Full update with server restart
- **Clear messaging**: Logs indicate whether restart is happening or not
- **Status tracking**: `NEEDS_SERVER_RESTART` flag for conditional logic

## Technical Details

### Why server restart is not needed for Web UI updates:

The server uses `http.FileServer(http.Dir(webRoot))` to serve static files (`server/transport.go:96-117`):
- Files are read from disk on each HTTP request
- No files are embedded in the binary (no `embed` package)
- Changes to Web UI files are immediately visible

### Backup strategy:

**All modes** backup both server binary and Web UI files:
- Maintains version consistency information
- Enables safe rollback without searching for matching binaries
- Simple and consistent backup structure

## Benefits

✅ **Zero downtime** for Web UI updates  
✅ **Faster updates** (no service restart overhead)  
✅ **Safe rollback** with complete backups  
✅ **Clear messaging** about update actions

## Testing

All checks passed:
- ✅ Go: fmt, vet, test, build
- ✅ Web UI: lint, typecheck, test, build (567 tests passed)
- ✅ shellcheck validation

## Example Output

**Web UI-only update:**
```
🔧 判定: Web UI ファイルに変更があります → Web UI ビルド（再起動不要）
🔄 Web UI ファイルを配置します（サーバー再起動なし）...
✅ Web UI ファイルの配置が完了しました（ダウンタイムなし）
```

**Go + Web UI update:**
```
🔧 判定: Go と Web UI の両方に変更があります → 全体ビルド + サーバー再起動
🔄 サービス更新を開始します（サーバー再起動あり）...
✅ サービス更新が完了しました
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)