### PR TITLE
refactor: unify device history storage limits and remove time filter

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -31,7 +31,6 @@ type PropertyDescription = echonet_lite.PropertyDescription
 
 type DeviceHistoryOptions struct {
 	Limit        int
-	Since        *time.Time
 	SettableOnly *bool
 }
 

--- a/client/websocket_history.go
+++ b/client/websocket_history.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
-	"time"
 
 	"echonet-list/protocol"
 )
@@ -18,10 +17,6 @@ func (c *WebSocketClient) GetDeviceHistory(device IPAndEOJ, opts DeviceHistoryOp
 	if opts.Limit > 0 {
 		limit := opts.Limit
 		payload.Limit = &limit
-	}
-
-	if opts.Since != nil {
-		payload.Since = opts.Since.UTC().Format(time.RFC3339Nano)
 	}
 
 	if opts.SettableOnly != nil {

--- a/client/websocket_history_test.go
+++ b/client/websocket_history_test.go
@@ -66,9 +66,9 @@ func TestGetDeviceHistorySuccess(t *testing.T) {
 		EOJ: echonet_lite.MakeEOJ(0x0130, 0x01),
 	}
 
-	since := time.Date(2024, 5, 1, 12, 0, 0, 0, time.UTC)
 	limit := 5
 	settableOnly := false
+	testTime := time.Date(2024, 5, 1, 12, 10, 0, 0, time.UTC)
 
 	var capturedPayload protocol.GetDeviceHistoryPayload
 	mock.handler = func(msg *protocol.Message) (*protocol.Message, error) {
@@ -80,7 +80,7 @@ func TestGetDeviceHistorySuccess(t *testing.T) {
 		}
 
 		entry := protocol.HistoryEntry{
-			Timestamp: since.Add(10 * time.Minute),
+			Timestamp: testTime,
 			EPC:       "80",
 			Value:     protocol.PropertyData{String: "on"},
 			Origin:    protocol.HistoryOriginSet,
@@ -104,7 +104,6 @@ func TestGetDeviceHistorySuccess(t *testing.T) {
 
 	opts := DeviceHistoryOptions{
 		Limit:        limit,
-		Since:        &since,
 		SettableOnly: &settableOnly,
 	}
 
@@ -118,9 +117,6 @@ func TestGetDeviceHistorySuccess(t *testing.T) {
 	}
 	if capturedPayload.Limit == nil || *capturedPayload.Limit != limit {
 		t.Fatalf("expected limit %d, got %v", limit, capturedPayload.Limit)
-	}
-	if capturedPayload.Since != since.Format(time.RFC3339Nano) {
-		t.Fatalf("unexpected since value: %s", capturedPayload.Since)
 	}
 	if capturedPayload.SettableOnly == nil || *capturedPayload.SettableOnly != settableOnly {
 		t.Fatalf("expected settableOnly false, got %v", capturedPayload.SettableOnly)

--- a/console/CommandTable.go
+++ b/console/CommandTable.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/c-bata/go-prompt"
 	"golang.org/x/exp/slices"
@@ -230,20 +229,6 @@ var CommandTable = []CommandDefinition{
 						return nil, fmt.Errorf("-limit には1以上の整数を指定してください")
 					}
 					cmd.HistoryOptions.Limit = value
-					argIndex += 2
-				case "-since":
-					if argIndex+1 >= len(parts) {
-						return nil, fmt.Errorf("-since オプションには時刻が必要です")
-					}
-					sinceStr := parts[argIndex+1]
-					timestamp, err := time.Parse(time.RFC3339Nano, sinceStr)
-					if err != nil {
-						timestamp, err = time.Parse(time.RFC3339, sinceStr)
-					}
-					if err != nil {
-						return nil, fmt.Errorf("-since の形式が不正です (RFC3339): %v", err)
-					}
-					cmd.HistoryOptions.Since = &timestamp
 					argIndex += 2
 				case "-all":
 					settable := false

--- a/console/history_command_test.go
+++ b/console/history_command_test.go
@@ -60,7 +60,7 @@ func (stubPropertyDescProvider) AvailablePropertyAliases(classCode client.EOJCla
 func TestParseHistoryCommand(t *testing.T) {
 	parser := NewCommandParser(stubPropertyDescProvider{}, stubAliasManager{}, stubGroupManager{})
 
-	cmd, err := parser.ParseCommand("history 192.168.1.20 0130:1 -limit 10 -since 2024-05-01T12:00:00Z -all", false)
+	cmd, err := parser.ParseCommand("history 192.168.1.20 0130:1 -limit 10 -all", false)
 	if err != nil {
 		t.Fatalf("ParseCommand returned error: %v", err)
 	}
@@ -71,9 +71,6 @@ func TestParseHistoryCommand(t *testing.T) {
 
 	if cmd.HistoryOptions.Limit != 10 {
 		t.Fatalf("expected limit 10, got %d", cmd.HistoryOptions.Limit)
-	}
-	if cmd.HistoryOptions.Since == nil || !cmd.HistoryOptions.Since.Equal(time.Date(2024, 5, 1, 12, 0, 0, 0, time.UTC)) {
-		t.Fatalf("unexpected since value: %v", cmd.HistoryOptions.Since)
 	}
 	if cmd.HistoryOptions.SettableOnly == nil || *cmd.HistoryOptions.SettableOnly {
 		t.Fatalf("expected settableOnly=false, got %v", cmd.HistoryOptions.SettableOnly)

--- a/docs/console_ui_usage.md
+++ b/docs/console_ui_usage.md
@@ -61,14 +61,13 @@ Gets property values from a specific device:
 ### Show Device History
 
 ```bash
-> history [ipAddress] classCode[:instanceCode] [-limit N] [-since RFC3339] [-all]
+> history [ipAddress] classCode[:instanceCode] [-limit N] [-all]
 ```
 
 Displays recent history for a specific device (newest first):
 
 - `ipAddress` / `classCode[:instanceCode]`: Target device (aliases are also accepted)
 - `-limit N`: Maximum number of entries to retrieve (default 50; capped by server retention)
-- `-since RFC3339`: Only show entries recorded after the given timestamp (e.g., `2024-05-01T12:00:00Z`)
 - `-all`: Include sensor notifications and other read-only changes (by default only writable properties are shown)
 
 Each entry shows the timestamp (local time), property name/EPC, value, origin (`set` or `notification`), and whether the property is writable.

--- a/docs/websocket_client_protocol.md
+++ b/docs/websocket_client_protocol.md
@@ -653,7 +653,6 @@ case 'device_added':
   "payload": {
     "target": "192.168.1.10 0130:1",
     "limit": 50,               // オプション: 取得件数の上限（既定値 50, サーバー設定値を超える場合は丸め込み）
-    "since": "2024-05-01T00:00:00Z", // オプション: この日時以降の履歴のみを取得（RFC3339 / RFC3339Nano）
     "settableOnly": true       // オプション: true で Set Property Map に含まれる履歴のみ（既定 true）
   },
   "requestId": "req-129"
@@ -662,7 +661,6 @@ case 'device_added':
 
 - `target`: デバイスID文字列（IP EOJ形式）。必須。
 - `limit`: 取得件数の上限。正の整数のみ許容。省略時は 50。
-- `since`: 絞り込み開始時刻。RFC3339 / RFC3339Nano 形式。省略時は全履歴。
 - `settableOnly`: `true` の場合、Set Property Map に含まれるプロパティのみ返します。省略時は `true`。
 
 レスポンスは `command_result` メッセージの `data` フィールドに以下の形式で返されます：

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -227,7 +227,6 @@ type UpdatePropertiesPayload struct {
 type GetDeviceHistoryPayload struct {
 	Target       string `json:"target"`
 	Limit        *int   `json:"limit,omitempty"`
-	Since        string `json:"since,omitempty"`
 	SettableOnly *bool  `json:"settableOnly,omitempty"`
 }
 

--- a/server/websocket_server_handlers_history.go
+++ b/server/websocket_server_handlers_history.go
@@ -4,24 +4,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
-	"time"
 
 	"echonet-list/echonet_lite/handler"
 	"echonet-list/protocol"
 )
 
 const defaultHistoryLimit = 50
-
-func parseHistorySince(value string) (time.Time, error) {
-	if value == "" {
-		return time.Time{}, nil
-	}
-
-	if ts, err := time.Parse(time.RFC3339Nano, value); err == nil {
-		return ts, nil
-	}
-	return time.Parse(time.RFC3339, value)
-}
 
 // handleGetDeviceHistoryFromClient handles a get_device_history message from a client.
 func (ws *WebSocketServer) handleGetDeviceHistoryFromClient(msg *protocol.Message) protocol.CommandResultPayload {
@@ -64,22 +52,12 @@ func (ws *WebSocketServer) handleGetDeviceHistoryFromClient(msg *protocol.Messag
 		limit = storeLimit
 	}
 
-	since := time.Time{}
-	if payload.Since != "" {
-		var err error
-		since, err = parseHistorySince(payload.Since)
-		if err != nil {
-			return ErrorResponse(protocol.ErrorCodeInvalidParameters, "Invalid since value: %v", err)
-		}
-	}
-
 	settableOnly := true
 	if payload.SettableOnly != nil {
 		settableOnly = *payload.SettableOnly
 	}
 
 	query := HistoryQuery{
-		Since: since,
 		Limit: limit,
 	}
 


### PR DESCRIPTION
## Summary

Unified device history storage to use a consistent 500-entry limit across save/load/memory operations and removed the unused `since` time filter functionality to simplify the codebase.

## Changes

### History Storage Unification
- **Added `trimToLimit()` helper method**: Centralized entry trimming logic that was previously duplicated across `Record()` and `LoadFromFile()`
- **Updated `DefaultHistoryLoadFilter()`**: Changed from 100 to 500 entries to match in-memory limit
- **Modified `LoadFromFile()`**: Removed time-based filtering and uses common trimming logic
- **Simplified `Record()`**: Now uses shared `trimToLimit()` helper

**Before**: Memory (500), Load (100), Save (all) → data loss on restart  
**After**: Memory (500), Load (500), Save (500) → no data loss

### Since Time Filter Removal
Removed unused time-based filtering from entire stack:

**Server** (`server/`):
- Removed `HistoryLoadFilter.Since` field
- Removed `HistoryQuery.Since` field  
- Removed `parseHistorySince()` function
- Removed time filter logic from `LoadFromFile()` and `Query()`
- Deleted `TestMemoryDeviceHistoryStore_QueryFilters` test
- Deleted `TestMemoryDeviceHistoryStore_LoadFromFile_TimeFilter` test

**Protocol** (`protocol/`):
- Removed `GetDeviceHistoryPayload.Since` field

**Client** (`client/`):
- Removed `DeviceHistoryOptions.Since` field
- Removed `Since` processing in `GetDeviceHistory()`
- Updated tests to remove `Since` assertions

**Console** (`console/`):
- Removed `-since` option parsing from `history` command
- Updated command test to remove `-since` usage

**Documentation** (`docs/`):
- Updated WebSocket protocol documentation
- Updated Console UI usage documentation

## Benefits

✅ **Eliminates data loss**: Previously lost up to 400 entries per device on restart  
✅ **Consolidates logic**: Single `trimToLimit()` method replaces duplicated code  
✅ **Reduces complexity**: Removed 164+ lines of unused time filter code  
✅ **Improves maintainability**: Unified configuration source (`DefaultHistoryOptions`)

## Testing

All tests pass successfully:

**Go**:
- ✅ `go fmt ./...` - No formatting issues
- ✅ `go vet ./...` - No vet warnings
- ✅ `go test ./...` - All packages pass
- ✅ `go build` - Build successful

**Web UI**:
- ✅ `npm run lint` - No linting errors
- ✅ `npm run typecheck` - No type errors
- ✅ `npm run test` - 571 tests pass
- ✅ `npm run build` - Build successful

## Migration Notes

No migration needed. The change is backward compatible:
- Existing `history.json` files will load correctly (up to 500 entries per device)
- API clients that were sending `since` parameter will continue to work (field is simply ignored)
- Console users using `-since` option will get a parse error and can simply remove it

🤖 Generated with [Claude Code](https://claude.com/claude-code)