### PR TITLE
cleanup: remove debug logging added in PR #362

### DIFF
--- a/echonet_lite/handler/DeviceHistory.go
+++ b/echonet_lite/handler/DeviceHistory.go
@@ -146,26 +146,13 @@ func (s *memoryDeviceHistoryStore) Record(entry DeviceHistoryEntry) {
 
 	// Add to appropriate map based on settable flag
 	if entry.Settable {
-		beforeCount := len(s.settableData[key])
 		entries := append(s.settableData[key], entry)
 		entries = s.trimToLimit(entries, s.perDeviceSettableLimit)
 		s.settableData[key] = entries
-
-		// Log if trimming occurred for settable history (to debug disappearing history issue)
-		if beforeCount+1 > s.perDeviceSettableLimit {
-			slog.Info("Trimmed settable history",
-				"device", key,
-				"epc", fmt.Sprintf("0x%02X", entry.EPC),
-				"before", beforeCount+1,
-				"after", len(entries),
-				"limit", s.perDeviceSettableLimit,
-				"dropped", (beforeCount+1)-len(entries))
-		}
 	} else {
 		entries := append(s.nonSettableData[key], entry)
 		entries = s.trimToLimit(entries, s.perDeviceLimit)
 		s.nonSettableData[key] = entries
-		// No logging for non-settable to avoid log spam from frequent sensor notifications
 	}
 }
 

--- a/server/websocket_server_handlers_history.go
+++ b/server/websocket_server_handlers_history.go
@@ -3,7 +3,6 @@ package server
 import (
 	"encoding/json"
 	"fmt"
-	"log/slog"
 	"strings"
 
 	"echonet-list/echonet_lite/handler"
@@ -65,13 +64,6 @@ func (ws *WebSocketServer) handleGetDeviceHistoryFromClient(msg *protocol.Messag
 
 	history := ws.GetHistoryStore().Query(ipAndEOJ, query)
 	resultEntries := make([]protocol.HistoryEntry, 0, len(history))
-
-	// Log history retrieval for settable-only queries
-	if settableOnly {
-		slog.Info("Get settable history",
-			"device", ipAndEOJ.Key(),
-			"returned", len(history))
-	}
 
 	for _, entry := range history {
 		// For event entries (online/offline), EPC is 0 and should be omitted from the response


### PR DESCRIPTION
## Summary

Remove temporary debug logging that was added in PR #362 to investigate the settable history disappearing issue.

## Background

PR #362 added debug logging to help diagnose why settable device history entries were disappearing:
- `"Trimmed settable history"` log in `DeviceHistory.go` 
- `"Get settable history"` log in `websocket_server_handlers_history.go`

The root cause has been identified and fixed in PR #363 (merged), so these debug logs are no longer needed and should be removed to avoid log clutter.

## Changes

- ✅ Remove `"Trimmed settable history"` log from `DeviceHistory.go`
- ✅ Remove `"Get settable history"` log from `websocket_server_handlers_history.go`
- ✅ Remove unused `log/slog` import from `websocket_server_handlers_history.go`
- ✅ Remove debug-related comments

## Testing

- ✅ All Go tests pass
- ✅ Code formatting and vet checks pass
- ✅ No functional changes, only debug log removal

## Related PRs

- PR #362: Added these debug logs for investigation
- PR #363: Fixed the root cause (settable history query issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)