### PR TITLE
npm(deps-dev): bump js-yaml from 4.1.0 to 4.1.1 in /web

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -5930,9 +5930,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary

- Fix moderate severity prototype pollution vulnerability in js-yaml (GHSA-mh29-5h37-fv8m)
- Update js-yaml from 4.1.0 to 4.1.1 in /web
- Applied via `npm audit fix`

## Security Advisory

- **Vulnerability**: Prototype pollution in merge (<<)
- **Severity**: Moderate
- **Reference**: https://github.com/advisories/GHSA-mh29-5h37-fv8m

## Test Plan

- [x] Go: fmt, vet, test, build - all passing
- [x] Web UI: lint, typecheck, test (608 tests), build - all passing
- [x] No WebSocket protocol changes detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)