### PR TITLE
feat(web): add date to notification bell timestamps for older logs

### DIFF
--- a/web/src/components/NotificationBell.test.tsx
+++ b/web/src/components/NotificationBell.test.tsx
@@ -305,6 +305,14 @@ describe('formatLogTime', () => {
     expect(result).toBe('10:25:30');
   });
 
+  it('returns padded time for midnight logs', () => {
+    // Today at 00:05:03 (local time)
+    const midnightLog = new Date();
+    midnightLog.setHours(0, 5, 3, 0);
+    const result = formatLogTime(midnightLog);
+    expect(result).toBe('00:05:03');
+  });
+
   it('returns date and time for yesterday logs', () => {
     // Yesterday at 10:25 (local time)
     const yesterdayLog = new Date();
@@ -324,15 +332,15 @@ describe('formatLogTime', () => {
     const result = formatLogTime(oldLog);
     const expectedMonth = oldLog.getMonth() + 1;
     const expectedDay = oldLog.getDate();
-    expect(result).toBe(`${expectedMonth}/${expectedDay} 8:05`);
+    expect(result).toBe(`${expectedMonth}/${expectedDay} 08:05`);
   });
 
-  it('pads minutes and seconds with zero when needed', () => {
+  it('pads hours, minutes and seconds with zero when needed', () => {
     // Today at 09:05:03 (local time)
     const todayLog = new Date();
     todayLog.setHours(9, 5, 3, 0);
     const result = formatLogTime(todayLog);
-    expect(result).toBe('9:05:03');
+    expect(result).toBe('09:05:03');
   });
 
   it('returns date with year for logs from previous year', () => {

--- a/web/src/components/NotificationBell.tsx
+++ b/web/src/components/NotificationBell.tsx
@@ -16,7 +16,7 @@ export function formatLogTime(date: Date): string {
   const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
   const logDate = new Date(date.getFullYear(), date.getMonth(), date.getDate());
 
-  const hours = date.getHours();
+  const hours = date.getHours().toString().padStart(2, '0');
   const minutes = date.getMinutes().toString().padStart(2, '0');
 
   if (logDate.getTime() >= today.getTime()) {


### PR DESCRIPTION
## Summary

- Add date display (M/D format) for notification logs from previous days
- Keep time with seconds (HH:mm:ss) for today's logs
- Add `formatLogTime` helper function with unit tests

### Display Format
- **Today's logs**: `HH:mm:ss` (e.g., `14:30:25`)
- **Previous days**: `M/D HH:mm` (e.g., `12/1 14:30`)

## Test plan

- [x] Unit tests for `formatLogTime` function pass
- [x] Lint check passes
- [x] Type check passes
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)