### PR TITLE
feat(web): add special layout for AC and floor heater in Dashboard

### DIFF
--- a/web/src/components/DashboardTabContent.tsx
+++ b/web/src/components/DashboardTabContent.tsx
@@ -1,5 +1,6 @@
 import { DashboardCard } from './DashboardCard';
 import { getDashboardDevicesGroupedByLocation, getLocationDisplayName } from '@/libs/locationHelper';
+import { arrangeDashboardDevices, isPlaceholder } from '@/libs/dashboardLayoutHelper';
 import type { Device, PropertyDescriptionData, DeviceAlias } from '@/hooks/types';
 
 interface DashboardTabContentProps {
@@ -50,17 +51,22 @@ export function DashboardTabContent({
 
             {/* Device grid within location */}
             <div className="grid grid-cols-2 gap-2">
-              {locationDevices.map(device => (
-                <DashboardCard
-                  key={`${device.ip} ${device.eoj}`}
-                  device={device}
-                  onPropertyChange={onPropertyChange}
-                  propertyDescriptions={propertyDescriptions}
-                  devices={devices}
-                  aliases={aliases}
-                  isConnected={isConnected}
-                />
-              ))}
+              {arrangeDashboardDevices(locationDevices).map((item, index) => {
+                if (isPlaceholder(item)) {
+                  return <div key={`placeholder-${index}`} />;
+                }
+                return (
+                  <DashboardCard
+                    key={`${item.ip} ${item.eoj}`}
+                    device={item}
+                    onPropertyChange={onPropertyChange}
+                    propertyDescriptions={propertyDescriptions}
+                    devices={devices}
+                    aliases={aliases}
+                    isConnected={isConnected}
+                  />
+                );
+              })}
             </div>
           </div>
         );

--- a/web/src/libs/dashboardLayoutHelper.test.ts
+++ b/web/src/libs/dashboardLayoutHelper.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect } from 'vitest';
+import { arrangeDashboardDevices, isPlaceholder, DashboardLayoutItem } from './dashboardLayoutHelper';
+import type { Device } from '@/hooks/types';
+
+// Helper to create mock device
+function createMockDevice(eoj: string, ip: string = '192.168.1.1'): Device {
+  return {
+    ip,
+    eoj,
+    name: `Device ${eoj}`,
+    id: `${eoj}:0001:001`,
+    properties: {},
+    lastSeen: new Date().toISOString(),
+  };
+}
+
+// Helper to extract device EOJs or 'placeholder' from layout
+function getLayoutPattern(items: DashboardLayoutItem[]): string[] {
+  return items.map(item => isPlaceholder(item) ? 'placeholder' : item.eoj);
+}
+
+describe('arrangeDashboardDevices', () => {
+  describe('air conditioner and floor heater pairing', () => {
+    it('should pair 1 air conditioner with 1 floor heater', () => {
+      const devices = [
+        createMockDevice('0130:1'), // Air conditioner
+        createMockDevice('027B:1'), // Floor heater
+      ];
+
+      const result = arrangeDashboardDevices(devices);
+
+      expect(getLayoutPattern(result)).toEqual(['0130:1', '027B:1']);
+    });
+
+    it('should pair 2 air conditioners with 1 floor heater (placeholder for missing floor heater)', () => {
+      const devices = [
+        createMockDevice('0130:1'), // Air conditioner 1
+        createMockDevice('0130:2'), // Air conditioner 2
+        createMockDevice('027B:1'), // Floor heater
+      ];
+
+      const result = arrangeDashboardDevices(devices);
+
+      // Row 1: AC1 | FH1
+      // Row 2: AC2 | placeholder
+      expect(getLayoutPattern(result)).toEqual(['0130:1', '027B:1', '0130:2', 'placeholder']);
+    });
+
+    it('should pair 1 air conditioner with 2 floor heaters (placeholder for missing air conditioner)', () => {
+      const devices = [
+        createMockDevice('0130:1'), // Air conditioner
+        createMockDevice('027B:1'), // Floor heater 1
+        createMockDevice('027B:2'), // Floor heater 2
+      ];
+
+      const result = arrangeDashboardDevices(devices);
+
+      // Row 1: AC1 | FH1
+      // Row 2: placeholder | FH2
+      expect(getLayoutPattern(result)).toEqual(['0130:1', '027B:1', 'placeholder', '027B:2']);
+    });
+
+    it('should handle air conditioner only (placeholder on right)', () => {
+      const devices = [
+        createMockDevice('0130:1'), // Air conditioner only
+      ];
+
+      const result = arrangeDashboardDevices(devices);
+
+      // Row 1: AC | placeholder
+      expect(getLayoutPattern(result)).toEqual(['0130:1', 'placeholder']);
+    });
+
+    it('should handle floor heater only (placeholder on left)', () => {
+      const devices = [
+        createMockDevice('027B:1'), // Floor heater only
+      ];
+
+      const result = arrangeDashboardDevices(devices);
+
+      // Row 1: placeholder | FH
+      expect(getLayoutPattern(result)).toEqual(['placeholder', '027B:1']);
+    });
+
+    it('should handle 2 air conditioners with 3 floor heaters', () => {
+      const devices = [
+        createMockDevice('0130:1'),
+        createMockDevice('0130:2'),
+        createMockDevice('027B:1'),
+        createMockDevice('027B:2'),
+        createMockDevice('027B:3'),
+      ];
+
+      const result = arrangeDashboardDevices(devices);
+
+      // Row 1: AC1 | FH1
+      // Row 2: AC2 | FH2
+      // Row 3: placeholder | FH3
+      expect(getLayoutPattern(result)).toEqual([
+        '0130:1', '027B:1',
+        '0130:2', '027B:2',
+        'placeholder', '027B:3'
+      ]);
+    });
+  });
+
+  describe('other devices placement', () => {
+    it('should place other devices after air conditioner/floor heater pairs', () => {
+      const devices = [
+        createMockDevice('0130:1'), // Air conditioner
+        createMockDevice('027B:1'), // Floor heater
+        createMockDevice('0291:1'), // Lighting
+        createMockDevice('0291:2'), // Lighting
+      ];
+
+      const result = arrangeDashboardDevices(devices);
+
+      // Row 1: AC | FH
+      // Row 2: Light1 | Light2
+      expect(getLayoutPattern(result)).toEqual(['0130:1', '027B:1', '0291:1', '0291:2']);
+    });
+
+    it('should handle only other devices (no special arrangement)', () => {
+      const devices = [
+        createMockDevice('0291:1'), // Lighting 1
+        createMockDevice('0291:2'), // Lighting 2
+      ];
+
+      const result = arrangeDashboardDevices(devices);
+
+      // No special arrangement, just sorted by EOJ
+      expect(getLayoutPattern(result)).toEqual(['0291:1', '0291:2']);
+    });
+
+    it('should handle mixed devices with uneven AC/FH counts', () => {
+      const devices = [
+        createMockDevice('0130:1'), // Air conditioner
+        createMockDevice('027B:1'), // Floor heater 1
+        createMockDevice('027B:2'), // Floor heater 2
+        createMockDevice('0291:1'), // Lighting
+      ];
+
+      const result = arrangeDashboardDevices(devices);
+
+      // Row 1: AC | FH1
+      // Row 2: placeholder | FH2
+      // Row 3: Light1 (normal flow)
+      expect(getLayoutPattern(result)).toEqual([
+        '0130:1', '027B:1',
+        'placeholder', '027B:2',
+        '0291:1'
+      ]);
+    });
+  });
+
+  describe('sorting within categories', () => {
+    it('should sort air conditioners by EOJ', () => {
+      const devices = [
+        createMockDevice('0130:2'), // Air conditioner 2 (added first)
+        createMockDevice('0130:1'), // Air conditioner 1
+        createMockDevice('027B:1'), // Floor heater
+      ];
+
+      const result = arrangeDashboardDevices(devices);
+
+      // AC1 should come before AC2
+      expect(getLayoutPattern(result)).toEqual(['0130:1', '027B:1', '0130:2', 'placeholder']);
+    });
+
+    it('should sort floor heaters by EOJ', () => {
+      const devices = [
+        createMockDevice('0130:1'), // Air conditioner
+        createMockDevice('027B:2'), // Floor heater 2 (added first)
+        createMockDevice('027B:1'), // Floor heater 1
+      ];
+
+      const result = arrangeDashboardDevices(devices);
+
+      // FH1 should come before FH2
+      expect(getLayoutPattern(result)).toEqual(['0130:1', '027B:1', 'placeholder', '027B:2']);
+    });
+
+    it('should sort other devices by EOJ', () => {
+      const devices = [
+        createMockDevice('0291:2'), // Lighting 2
+        createMockDevice('0291:1'), // Lighting 1
+      ];
+
+      const result = arrangeDashboardDevices(devices);
+
+      expect(getLayoutPattern(result)).toEqual(['0291:1', '0291:2']);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle empty device array', () => {
+      const result = arrangeDashboardDevices([]);
+      expect(result).toEqual([]);
+    });
+
+    it('should handle multiple floor heaters only', () => {
+      const devices = [
+        createMockDevice('027B:1'),
+        createMockDevice('027B:2'),
+      ];
+
+      const result = arrangeDashboardDevices(devices);
+
+      // Row 1: placeholder | FH1
+      // Row 2: placeholder | FH2
+      expect(getLayoutPattern(result)).toEqual([
+        'placeholder', '027B:1',
+        'placeholder', '027B:2'
+      ]);
+    });
+
+    it('should handle multiple air conditioners only', () => {
+      const devices = [
+        createMockDevice('0130:1'),
+        createMockDevice('0130:2'),
+      ];
+
+      const result = arrangeDashboardDevices(devices);
+
+      // Row 1: AC1 | placeholder
+      // Row 2: AC2 | placeholder
+      expect(getLayoutPattern(result)).toEqual([
+        '0130:1', 'placeholder',
+        '0130:2', 'placeholder'
+      ]);
+    });
+  });
+});
+
+describe('isPlaceholder', () => {
+  it('should return true for placeholder object', () => {
+    expect(isPlaceholder({ type: 'placeholder' })).toBe(true);
+  });
+
+  it('should return false for device object', () => {
+    const device = createMockDevice('0130:1');
+    expect(isPlaceholder(device)).toBe(false);
+  });
+});

--- a/web/src/libs/dashboardLayoutHelper.ts
+++ b/web/src/libs/dashboardLayoutHelper.ts
@@ -1,0 +1,106 @@
+// Dashboard layout helper for special air conditioner / floor heater arrangement
+
+import type { Device } from '@/hooks/types';
+
+// Placeholder type for empty grid slots
+export type Placeholder = { type: 'placeholder' };
+
+// Layout item can be either a Device or a Placeholder
+export type DashboardLayoutItem = Device | Placeholder;
+
+/**
+ * Type guard to check if an item is a placeholder
+ */
+export function isPlaceholder(item: DashboardLayoutItem): item is Placeholder {
+  return 'type' in item && item.type === 'placeholder';
+}
+
+// Device class codes for special layout handling
+const CLASS_AIR_CONDITIONER = '0130';
+const CLASS_FLOOR_HEATER = '027B';
+
+/**
+ * Extract class code from EOJ (format: "classCode:instance")
+ */
+function getClassCode(device: Device): string {
+  return device.eoj.split(':')[0];
+}
+
+/**
+ * Check if device is an air conditioner
+ */
+function isAirConditioner(device: Device): boolean {
+  return getClassCode(device) === CLASS_AIR_CONDITIONER;
+}
+
+/**
+ * Check if device is a floor heater
+ */
+function isFloorHeater(device: Device): boolean {
+  return getClassCode(device) === CLASS_FLOOR_HEATER;
+}
+
+/**
+ * Sort devices by EOJ (classCode:instance)
+ */
+function sortByEOJ(devices: Device[]): Device[] {
+  return [...devices].sort((a, b) => a.eoj.localeCompare(b.eoj));
+}
+
+/**
+ * Create a placeholder for empty grid slots
+ */
+function createPlaceholder(): Placeholder {
+  return { type: 'placeholder' };
+}
+
+/**
+ * Arrange devices for Dashboard grid layout with special handling for
+ * air conditioners (class 0130) and floor heaters (class 027B).
+ *
+ * Layout rules:
+ * - If AC or floor heater exists, pair them: left = AC, right = floor heater
+ * - If counts don't match, use placeholders for empty slots
+ * - Other devices follow after the AC/FH pairs in normal EOJ order
+ */
+export function arrangeDashboardDevices(devices: Device[]): DashboardLayoutItem[] {
+  if (devices.length === 0) {
+    return [];
+  }
+
+  // Categorize devices
+  const airConditioners = sortByEOJ(devices.filter(isAirConditioner));
+  const floorHeaters = sortByEOJ(devices.filter(isFloorHeater));
+  const others = sortByEOJ(devices.filter(d => !isAirConditioner(d) && !isFloorHeater(d)));
+
+  // If no AC or floor heaters, return others in sorted order
+  if (airConditioners.length === 0 && floorHeaters.length === 0) {
+    return others;
+  }
+
+  const result: DashboardLayoutItem[] = [];
+
+  // Create paired rows for AC and floor heaters
+  const maxPairs = Math.max(airConditioners.length, floorHeaters.length);
+
+  for (let i = 0; i < maxPairs; i++) {
+    // Left column: air conditioner or placeholder
+    if (i < airConditioners.length) {
+      result.push(airConditioners[i]);
+    } else {
+      result.push(createPlaceholder());
+    }
+
+    // Right column: floor heater or placeholder
+    if (i < floorHeaters.length) {
+      result.push(floorHeaters[i]);
+    } else {
+      result.push(createPlaceholder());
+    }
+  }
+
+  // Add remaining devices
+  result.push(...others);
+
+  return result;
+}


### PR DESCRIPTION
## Summary

- Dashboard の各部屋(location)内で、エアコン(0130)と床暖房(027B)を左右ペアで配置する特殊レイアウトを追加
- 左列にエアコン、右列に床暖房を配置
- 台数が合わない場合はプレースホルダーでグリッドレイアウトを維持
- その他のデバイスはエアコン・床暖房ペアの後にEOJ順で配置

## Test plan

- [x] `npm run test` - 17件の新規テストを含む全テストがパス
- [x] `npm run lint` - エラーなし
- [x] `npm run typecheck` - エラーなし
- [x] `npm run build` - ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)