### PR TITLE
fix(web): add bottom safe-area padding for mobile navigation bars

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>ECHONET List</title>
     <style>
       .bundle-error-overlay {

--- a/web/src/components/DashboardTabContent.tsx
+++ b/web/src/components/DashboardTabContent.tsx
@@ -33,7 +33,7 @@ export function DashboardTabContent({
 
   return (
     <div
-      className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4 items-start"
+      className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4 items-start pb-16 safe-area-bottom"
       data-testid="dashboard-content"
     >
       {locationIds.map(locationId => {

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -128,6 +128,11 @@
       background-color: hsl(240 5% 64.9%);
     }
   }
+
+  /* Safe area support for mobile devices with notch/home indicator */
+  .safe-area-bottom {
+    padding-bottom: env(safe-area-inset-bottom, 1rem);
+  }
 }
 
 


### PR DESCRIPTION
## Summary

- スマホ実機でOS操作バー（iPhoneホームインジケーター、Androidジェスチャーバー）との干渉を防止
- Dashboard下部に適切な余白を追加

## Changes

- `web/index.html` - `viewport-fit=cover` を追加してiOS safe-area有効化
- `web/src/index.css` - `safe-area-bottom` クラスを追加（env(safe-area-inset-bottom) 対応）
- `web/src/components/DashboardTabContent.tsx` - `pb-16 safe-area-bottom` で下部余白追加

## Technical Details

- `pb-16` = 64px の固定余白（ベースライン）
- `env(safe-area-inset-bottom, 1rem)` = iOS safe-areaがあればその値を使用、なければ1rem

## Test plan

- [x] `npm run lint` - OK
- [x] `npm run typecheck` - OK
- [x] `npm run test` - OK
- [x] `npm run build` - OK
- [ ] スマホ実機でOS操作バーとコンテンツが干渉しないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)