### PR TITLE
feat(web): modernize UI with Tech Dashboard design

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -435,10 +435,10 @@ function App() {
   return (
     <div className="min-h-screen bg-background text-foreground" style={{ scrollBehavior: 'smooth', scrollPaddingTop: '4rem' }}>
       {/* Sticky Header */}
-      <div className="sticky top-0 z-50 bg-background/80 backdrop-blur-sm backdrop-saturate-150 border-b border-border transition-all duration-200" style={{ willChange: 'transform' }}>
+      <div className="sticky top-0 z-50 bg-background/70 backdrop-blur-md backdrop-saturate-150 border-b border-border/50 shadow-sm transition-all duration-200" style={{ willChange: 'transform' }}>
         <div className="container mx-auto px-4 py-2">
           <div className="flex justify-between items-center">
-            <h1 className="text-2xl sm:text-3xl font-bold">ECHONET List</h1>
+            <h1 className="text-2xl sm:text-3xl font-bold font-display tracking-tight bg-gradient-to-r from-primary to-teal-400 bg-clip-text text-transparent">ECHONET List</h1>
             <div className="flex items-center gap-1 sm:gap-2">
               {/* Refresh All Offline Button */}
               <RefreshAllOfflineButton
@@ -496,23 +496,23 @@ function App() {
                   <TabsTrigger
                     key={tabId}
                     value={tabId}
-                    className="data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:border-primary border-2 border-muted-foreground/30 bg-background px-2 sm:px-3 py-1.5 sm:py-2 text-xs sm:text-sm rounded-lg"
+                    className="data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:shadow-lg data-[state=active]:shadow-primary/20 border border-border/50 bg-card/50 px-2.5 sm:px-3.5 py-2 sm:py-2.5 text-xs sm:text-sm rounded-xl transition-all duration-200 hover:bg-accent/30"
                     data-testid={`tab-${tabId}`}
                   >
-                    <div className="flex items-center gap-1">
+                    <div className="flex items-center gap-1.5">
                       {showStatusIndicators && (
                         <div className="flex items-center gap-1">
                           <div
-                            className={`w-2 h-2 rounded-full ${
+                            className={`w-2 h-2 rounded-full transition-all duration-300 ${
                               hasOperationalDevice
-                                ? 'bg-green-500'
-                                : 'border-2 border-gray-400 bg-transparent'
+                                ? 'bg-teal-400 shadow-[0_0_6px_2px_hsl(160_75%_50%/0.5)]'
+                                : 'border border-muted-foreground/40 bg-transparent'
                             }`}
                             title={`Power Status: ${hasOperationalDevice ? 'At least one device is ON' : 'All devices are OFF or no devices'}`}
                           />
                           {hasFaultyDevice && (
                             <div
-                              className="w-2 h-2 rounded-full bg-red-500"
+                              className="w-2 h-2 rounded-full bg-red-500 shadow-[0_0_6px_2px_hsl(0_80%_55%/0.5)]"
                               title="At least one device has a fault"
                             />
                           )}
@@ -520,7 +520,7 @@ function App() {
                       )}
                       <span>{displayName}</span>
                       {showDeviceCount && (
-                        <span className="ml-1 text-[10px] sm:text-xs">({tabDevices.length})</span>
+                        <span className="ml-1 text-[10px] sm:text-xs opacity-70">({tabDevices.length})</span>
                       )}
                     </div>
                   </TabsTrigger>

--- a/web/src/components/ConnectionStatusBadge.test.tsx
+++ b/web/src/components/ConnectionStatusBadge.test.tsx
@@ -42,9 +42,9 @@ describe('ConnectionStatusBadge', () => {
   it('should apply correct color classes for each state', () => {
     const states: ConnectionState[] = ['connected', 'disconnected', 'connecting', 'error'];
     const expectedColors = {
-      connected: 'bg-green-500',
-      disconnected: 'bg-gray-500',
-      connecting: 'bg-yellow-500',
+      connected: 'bg-teal-500',
+      disconnected: 'bg-slate-500',
+      connecting: 'bg-amber-500',
       error: 'bg-red-500'
     };
 

--- a/web/src/components/ConnectionStatusBadge.tsx
+++ b/web/src/components/ConnectionStatusBadge.tsx
@@ -27,15 +27,15 @@ export function ConnectionStatusBadge({ connectionState }: ConnectionStatusBadge
   const getConnectionColor = (state: ConnectionState) => {
     switch (state) {
       case 'connected':
-        return 'bg-green-500 text-white dark:bg-green-900 dark:text-green-100';
+        return 'bg-teal-500 text-white shadow-sm shadow-teal-500/30 dark:bg-teal-600 dark:text-teal-50';
       case 'connecting':
-        return 'bg-yellow-500 text-black dark:bg-yellow-900 dark:text-yellow-100';
+        return 'bg-amber-500 text-white dark:bg-amber-600 dark:text-amber-50';
       case 'disconnected':
-        return 'bg-gray-500 text-white dark:bg-gray-800 dark:text-gray-100';
+        return 'bg-slate-500 text-white dark:bg-slate-700 dark:text-slate-200';
       case 'error':
-        return 'bg-red-500 text-white dark:bg-red-900 dark:text-red-100';
+        return 'bg-red-500 text-white shadow-sm shadow-red-500/30 dark:bg-red-600 dark:text-red-50';
       default:
-        return 'bg-gray-500 text-white dark:bg-gray-800 dark:text-gray-100';
+        return 'bg-slate-500 text-white dark:bg-slate-700 dark:text-slate-200';
     }
   };
 

--- a/web/src/components/DashboardCard.test.tsx
+++ b/web/src/components/DashboardCard.test.tsx
@@ -394,10 +394,10 @@ describe('DashboardCard', () => {
       );
 
       const card = screen.getByTestId('dashboard-card-192.168.1.100-0130:1');
-      expect(card).toHaveClass('border-green-500/60');
+      expect(card).toHaveClass('border-teal-500/50');
     });
 
-    it('should not have green border when device is off', () => {
+    it('should not have teal border when device is off', () => {
       const offDevice = createDevice({
         properties: {
           '80': { string: 'off' },
@@ -419,7 +419,7 @@ describe('DashboardCard', () => {
       );
 
       const card = screen.getByTestId('dashboard-card-192.168.1.100-0130:1');
-      expect(card).not.toHaveClass('border-green-500/60');
+      expect(card).not.toHaveClass('border-teal-500/50');
     });
   });
 });

--- a/web/src/components/DashboardCard.tsx
+++ b/web/src/components/DashboardCard.tsx
@@ -80,9 +80,11 @@ export function DashboardCard({
   return (
     <Card
       className={cn(
-        'py-1 px-2 border-2',
+        'py-1.5 px-2.5 border transition-all duration-200',
         isOffline && 'opacity-50',
-        isOperational ? 'border-green-500/60' : 'border-border'
+        isOperational
+          ? 'border-teal-500/50 shadow-sm shadow-teal-500/10'
+          : 'border-border/60'
       )}
       data-testid={`dashboard-card-${device.ip}-${device.eoj}`}
     >

--- a/web/src/components/DashboardTabContent.tsx
+++ b/web/src/components/DashboardTabContent.tsx
@@ -44,7 +44,7 @@ export function DashboardTabContent({
         const firstIsPlaceholder = arranged.length > 0 && isPlaceholder(arranged[0]);
 
         const locationLabel = (
-          <h3 className="text-sm font-semibold text-muted-foreground px-1 md:px-0">
+          <h3 className="text-sm font-semibold font-display text-muted-foreground/80 uppercase tracking-wide px-1 md:px-0">
             {locationName}
           </h3>
         );

--- a/web/src/components/DeviceCard.tsx
+++ b/web/src/components/DeviceCard.tsx
@@ -72,10 +72,10 @@ export function DeviceCard({
       return 'border-muted-foreground/30';
     }
     if (isFaulty) {
-      return 'border-red-500/60';
+      return 'border-red-500/60 glow-error';
     }
     if (isOperational && isControllable) {
-      return 'border-green-500/60';
+      return 'border-teal-500/60 glow-on';
     }
     return 'border-border'; // Default border
   };

--- a/web/src/components/ui/card.tsx
+++ b/web/src/components/ui/card.tsx
@@ -9,7 +9,7 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "rounded-lg border bg-card text-card-foreground shadow-sm",
+      "rounded-xl border bg-card text-card-foreground shadow-sm transition-all duration-200",
       className
     )}
     {...props}

--- a/web/src/components/ui/tabs.tsx
+++ b/web/src/components/ui/tabs.tsx
@@ -12,7 +12,7 @@ const TabsList = React.forwardRef<
   <TabsPrimitive.List
     ref={ref}
     className={cn(
-      "inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground",
+      "inline-flex h-auto items-center justify-center rounded-xl bg-muted/60 p-1.5 text-muted-foreground",
       className
     )}
     {...props}
@@ -27,7 +27,7 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
+      "inline-flex items-center justify-center whitespace-nowrap rounded-lg px-3 py-2 text-sm font-medium ring-offset-background transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:shadow-md hover:bg-accent/50",
       className
     )}
     {...props}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1,62 +1,71 @@
 @import "tailwindcss";
 
+/* Google Fonts - Space Grotesk (display) + IBM Plex Sans (body) */
+@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600&family=Space+Grotesk:wght@400;500;600;700&display=swap');
+
 @theme {
-  --radius: 0.5rem;
-  
-  /* Color definitions in v4 format */
-  --color-border: hsl(240 5.9% 90%);
-  --color-input: hsl(240 5.9% 90%);
-  --color-ring: hsl(240 5.9% 10%);
-  --color-background: hsl(0 0% 100%);
-  --color-foreground: hsl(240 10% 3.9%);
-  --color-primary: hsl(240 9% 10%);
-  --color-primary-foreground: hsl(0 0% 98%);
-  --color-secondary: hsl(240 4.8% 95.9%);
-  --color-secondary-foreground: hsl(240 5.9% 10%);
-  --color-destructive: hsl(0 84.2% 60.2%);
-  --color-destructive-foreground: hsl(0 0% 98%);
-  --color-muted: hsl(240 4.8% 95.9%);
-  --color-muted-foreground: hsl(240 3.8% 46.1%);
-  --color-accent: hsl(240 4.8% 95.9%);
-  --color-accent-foreground: hsl(240 5.9% 10%);
+  --radius: 0.625rem;
+
+  /* Typography */
+  --font-sans: 'IBM Plex Sans', system-ui, sans-serif;
+  --font-display: 'Space Grotesk', system-ui, sans-serif;
+
+  /* Teal/Cyan accent palette - Light Theme */
+  --color-border: hsl(180 15% 85%);
+  --color-input: hsl(180 10% 88%);
+  --color-ring: hsl(175 70% 40%);
+  --color-background: hsl(200 20% 98%);
+  --color-foreground: hsl(200 25% 10%);
+  --color-primary: hsl(175 70% 38%);
+  --color-primary-foreground: hsl(0 0% 100%);
+  --color-secondary: hsl(200 15% 94%);
+  --color-secondary-foreground: hsl(200 20% 20%);
+  --color-destructive: hsl(0 80% 55%);
+  --color-destructive-foreground: hsl(0 0% 100%);
+  --color-muted: hsl(200 15% 94%);
+  --color-muted-foreground: hsl(200 10% 45%);
+  --color-accent: hsl(180 20% 92%);
+  --color-accent-foreground: hsl(175 70% 30%);
   --color-popover: hsl(0 0% 100%);
-  --color-popover-foreground: hsl(240 10% 3.9%);
+  --color-popover-foreground: hsl(200 25% 10%);
   --color-card: hsl(0 0% 100%);
-  --color-card-foreground: hsl(240 10% 3.9%);
-  --color-chart-1: hsl(12 76% 61%);
-  --color-chart-2: hsl(173 58% 39%);
-  --color-chart-3: hsl(197 37% 24%);
-  --color-chart-4: hsl(43 74% 66%);
-  --color-chart-5: hsl(27 87% 67%);
+  --color-card-foreground: hsl(200 25% 10%);
+  /* Chart colors */
+  --color-chart-1: hsl(175 70% 45%);
+  --color-chart-2: hsl(200 60% 50%);
+  --color-chart-3: hsl(30 80% 55%);
+  --color-chart-4: hsl(280 60% 55%);
+  --color-chart-5: hsl(340 70% 55%);
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
-    /* Dark theme colors */
-    --color-border: hsl(240 3.7% 25%);
-    --color-input: hsl(240 3.7% 15.9%);
-    --color-ring: hsl(240 4.9% 83.9%);
-    --color-background: hsl(240 10% 3.9%);
-    --color-foreground: hsl(0 0% 98%);
-    --color-primary: hsl(0 0% 98%);
-    --color-primary-foreground: hsl(240 5.9% 10%);
-    --color-secondary: hsl(240 3.7% 15.9%);
-    --color-secondary-foreground: hsl(0 0% 98%);
-    --color-destructive: hsl(0 75% 45%);
-    --color-destructive-foreground: hsl(0 0% 98%);
-    --color-muted: hsl(240 3.7% 15.9%);
-    --color-muted-foreground: hsl(240 5% 64.9%);
-    --color-accent: hsl(240 3.7% 15.9%);
-    --color-accent-foreground: hsl(0 0% 98%);
-    --color-popover: hsl(240 10% 3.9%);
-    --color-popover-foreground: hsl(0 0% 98%);
-    --color-card: hsl(240 10% 3.9%);
-    --color-card-foreground: hsl(0 0% 98%);
-    --color-chart-1: hsl(220 70% 50%);
-    --color-chart-2: hsl(160 60% 45%);
-    --color-chart-3: hsl(30 80% 55%);
-    --color-chart-4: hsl(280 65% 60%);
-    --color-chart-5: hsl(340 75% 55%);
+    /* Dark theme colors - Teal/Cyan accent */
+    --color-border: hsl(200 20% 22%);
+    --color-input: hsl(200 20% 15%);
+    --color-ring: hsl(175 60% 50%);
+    --color-background: hsl(210 25% 8%);
+    --color-foreground: hsl(180 15% 95%);
+    --color-primary: hsl(175 65% 50%);
+    --color-primary-foreground: hsl(200 25% 8%);
+    --color-secondary: hsl(200 20% 15%);
+    --color-secondary-foreground: hsl(180 15% 90%);
+    --color-destructive: hsl(0 70% 50%);
+    --color-destructive-foreground: hsl(0 0% 100%);
+    --color-muted: hsl(200 20% 15%);
+    --color-muted-foreground: hsl(200 15% 55%);
+    --color-accent: hsl(180 25% 18%);
+    --color-accent-foreground: hsl(175 65% 60%);
+    --color-popover: hsl(210 22% 12%);
+    --color-popover-foreground: hsl(180 15% 95%);
+    --color-card: hsl(210 22% 12%);
+    --color-card-foreground: hsl(180 15% 95%);
+    /* Chart colors - Dark */
+    --color-chart-1: hsl(175 70% 55%);
+    --color-chart-2: hsl(200 65% 55%);
+    --color-chart-3: hsl(30 85% 60%);
+    --color-chart-4: hsl(280 65% 65%);
+    --color-chart-5: hsl(340 75% 60%);
   }
 }
 
@@ -66,6 +75,13 @@
   }
   body {
     @apply bg-background text-foreground;
+    font-family: var(--font-sans);
+  }
+
+  /* Display font for headings */
+  h1, h2, h3, h4, .font-display {
+    font-family: var(--font-display);
+    letter-spacing: -0.02em;
   }
   
   /* Optimize touch interactions on mobile */
@@ -135,4 +151,21 @@
   }
 }
 
+@layer components {
+  /* Status glow effects for device cards */
+  .glow-on {
+    box-shadow: 0 0 0 1px hsl(160 75% 42% / 0.3), 0 4px 12px hsl(160 75% 42% / 0.15);
+  }
+  .glow-error {
+    box-shadow: 0 0 0 1px hsl(0 80% 55% / 0.3), 0 4px 12px hsl(0 80% 55% / 0.15);
+  }
+}
 
+@media (prefers-color-scheme: dark) {
+  .glow-on {
+    box-shadow: 0 0 0 1px hsl(160 80% 50% / 0.4), 0 4px 20px hsl(160 80% 50% / 0.2);
+  }
+  .glow-error {
+    box-shadow: 0 0 0 1px hsl(0 75% 55% / 0.4), 0 4px 20px hsl(0 75% 55% / 0.2);
+  }
+}

--- a/web/src/libs/deviceIconHelper.test.ts
+++ b/web/src/libs/deviceIconHelper.test.ts
@@ -66,16 +66,16 @@ describe('deviceIconHelper', () => {
       expect(getDeviceIconColor(false, true, false)).toBe('text-red-500');
     });
 
-    it('should return green color for operational controllable device', () => {
-      expect(getDeviceIconColor(true, false, false, true)).toBe('text-green-500');
+    it('should return teal color for operational controllable device', () => {
+      expect(getDeviceIconColor(true, false, false, true)).toBe('text-teal-500');
     });
 
-    it('should return gray color for operational non-controllable device', () => {
-      expect(getDeviceIconColor(true, false, false, false)).toBe('text-gray-400');
+    it('should return muted color for operational non-controllable device', () => {
+      expect(getDeviceIconColor(true, false, false, false)).toBe('text-muted-foreground/60');
     });
 
-    it('should return gray color for non-operational device', () => {
-      expect(getDeviceIconColor(false, false, false)).toBe('text-gray-400');
+    it('should return muted color for non-operational device', () => {
+      expect(getDeviceIconColor(false, false, false)).toBe('text-muted-foreground/60');
     });
 
     it('should show fault state even for non-controllable devices', () => {

--- a/web/src/libs/deviceIconHelper.ts
+++ b/web/src/libs/deviceIconHelper.ts
@@ -79,9 +79,9 @@ export function getDeviceIconColor(
     if (isFaulty) {
       return 'text-red-500';
     }
-    return 'text-gray-400'; // No status coloring for non-controllable devices
+    return 'text-muted-foreground/60'; // No status coloring for non-controllable devices
   }
-  
+
   // For controllable devices, show full status coloring
   if (isOffline) {
     return 'text-muted-foreground';
@@ -90,7 +90,7 @@ export function getDeviceIconColor(
     return 'text-red-500';
   }
   if (isOperational) {
-    return 'text-green-500';
+    return 'text-teal-500';
   }
-  return 'text-gray-400';
+  return 'text-muted-foreground/60';
 }


### PR DESCRIPTION
## Summary
- Web UIをTech Dashboardスタイルでモダン化
- Teal/Cyanアクセントカラーに統一
- Space Grotesk + IBM Plex Sans のタイポグラフィ導入
- デバイスカードにグロー効果追加
- ライト/ダークモード両対応

## Changes
- **Typography**: Space Grotesk (display) + IBM Plex Sans (body)フォント追加
- **Color Palette**: Teal/Cyan系のアクセントカラーに変更
- **Card Design**: rounded-xl、transition効果、グロー効果追加
- **Tab Navigation**: モダンなタブスタイル、アクティブ状態でシャドウ
- **Status Indicators**: Tealグロー効果付きのステータスドット
- **Header**: グラデーションタイトルテキスト

## Test plan
- [x] npm run typecheck - パス
- [x] npm run lint - パス  
- [x] npm run test - 711テストパス
- [x] npm run build - 成功
- [x] Chrome (PC) で動作確認
- [ ] iPhone Safari で動作確認
- [x] ダークモード表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)