### PR TITLE
feat: INF受信時にリトライカウントをリセット

### DIFF
--- a/echonet_lite/handler/handler_communication.go
+++ b/echonet_lite/handler/handler_communication.go
@@ -292,6 +292,10 @@ func (h *CommunicationHandler) onInfMessage(ip net.IP, msg *echonet_lite.ECHONET
 	slog.Info("INFメッセージを受信", "ip", ip, "SEOJ", msg.SEOJ, "DEOJ", msg.DEOJ, "ESV", msg.ESV, "Properties", msg.Properties.String(msg.SEOJ.ClassCode()))
 	// fmt.Printf("INFメッセージを受信: %v %v, DEOJ:%v\n", ip, msg.SEOJ, msg.DEOJ) // DEBUG
 
+	// デバイスの生存確認を記録（リトライ中のタイムアウト判定に使用）
+	sourceDevice := echonet_lite.IPAndEOJ{IP: ip, EOJ: msg.SEOJ}
+	h.session.SignalDeviceAlive(sourceDevice)
+
 	// DEOJ は instanceCode = 0 (ワイルドカード) の場合がある
 	if found := h.localDevices.FindEOJ(msg.DEOJ); len(found) == 0 {
 		// 許容できないDEOJをもつmsgは破棄


### PR DESCRIPTION
## Summary
- デバイスからINFメッセージを受信した場合、リトライカウントをリセットする機能を追加
- 冷蔵庫のようにGET要求に応答しないがINFを送信するデバイスのオフライン誤判定を防止
- INFを送り続ける限りデバイスはオフライン判定されない

## Changes
- `Session.go`: `lastAliveTime` マップと `SignalDeviceAlive()` メソッドを追加
- `waitForResponseWithRetry()`: タイムアウト時に最後のリトライ以降にINF受信があればリトライカウントをリセット
- `handler_communication.go`: `onInfMessage()` でINF受信時に `SignalDeviceAlive()` を呼び出し

## Test plan
- [x] 新規テスト追加（SignalDeviceAlive, makeAliveKey, 複数デバイス独立性）
- [x] 既存テスト全て通過
- [x] ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)