### PR TITLE
Lazy load LocationSettingsDialog to reduce bundle size

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -20,8 +20,12 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Plus, Settings } from 'lucide-react';
-import { LocationSettingsDialog } from '@/components/LocationSettingsDialog';
-import { useState, useEffect, useMemo, useRef, useCallback } from 'react';
+import { useState, useEffect, useMemo, useRef, useCallback, Suspense, lazy } from 'react';
+
+// Lazy load heavy dialog to reduce initial bundle size
+const LocationSettingsDialog = lazy(() =>
+  import('@/components/LocationSettingsDialog').then(m => ({ default: m.LocationSettingsDialog }))
+);
 import type { PropertyValue } from '@/hooks/types';
 import type { LogEntry } from '@/hooks/useLogNotifications';
 
@@ -726,18 +730,20 @@ function App() {
       </div>
 
       {/* Location Settings Dialog */}
-      <LocationSettingsDialog
-        isOpen={isLocationSettingsOpen}
-        onOpenChange={setIsLocationSettingsOpen}
-        locationSettings={echonet.locationSettings}
-        availableLocations={availableLocations}
-        devices={echonet.devices}
-        propertyDescriptions={echonet.propertyDescriptions}
-        onAddLocationAlias={echonet.addLocationAlias}
-        onDeleteLocationAlias={echonet.deleteLocationAlias}
-        onSetLocationOrder={echonet.setLocationOrder}
-        isConnected={isConnected}
-      />
+      <Suspense fallback={null}>
+        <LocationSettingsDialog
+          isOpen={isLocationSettingsOpen}
+          onOpenChange={setIsLocationSettingsOpen}
+          locationSettings={echonet.locationSettings}
+          availableLocations={availableLocations}
+          devices={echonet.devices}
+          propertyDescriptions={echonet.propertyDescriptions}
+          onAddLocationAlias={echonet.addLocationAlias}
+          onDeleteLocationAlias={echonet.deleteLocationAlias}
+          onSetLocationOrder={echonet.setLocationOrder}
+          isConnected={isConnected}
+        />
+      </Suspense>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Apply `React.lazy()` and `Suspense` to `LocationSettingsDialog` component
- Splits heavy `@dnd-kit` dependencies into a separate lazy-loaded chunk
- Reduces main bundle size from 522.71 kB to 470.81 kB (51.9 kB reduction)
- Eliminates Vite chunk size warning (500 kB threshold)

## Changes

- `web/src/App.tsx`: Convert static import to dynamic import with `React.lazy()`

## Bundle Size Comparison

| Chunk | Before | After |
|-------|--------|-------|
| Main bundle | 522.71 kB | 470.81 kB |
| LocationSettingsDialog (lazy) | - | 53.28 kB |

## Test plan

- [x] `go test ./...` - All Go tests pass
- [x] `npm run lint` - No lint errors
- [x] `npm run typecheck` - No type errors
- [x] `npm run test` - All 744 web tests pass
- [x] `npm run build` - Build successful, no chunk size warning
- [x] Manual: Verify location settings dialog opens correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)