### PR TITLE
Update merge-dependabot skill to use auto-merge chain approach

### DIFF
--- a/.claude/commands/merge-dependabot.md
+++ b/.claude/commands/merge-dependabot.md
@@ -20,9 +20,7 @@ Merge all safe dependabot PRs efficiently and automatically:
 5. **Set auto-merge on approved PRs**:
 
    ```bash
-   for pr in <approved PR numbers>; do
-     gh pr merge $pr --squash --auto
-   done
+   echo "<approved PR numbers>" | xargs -n1 gh pr merge --squash --auto
    ```
 
 6. **Kick off the oldest PR**: Run `gh pr update-branch` on the lowest-numbered (oldest) PR to start the chain. The oldest PR typically has the most up-to-date CI results and is most likely to merge immediately.


### PR DESCRIPTION
## Summary

- Changed from sequential PR processing to auto-merge chain approach
- All approved PRs get auto-merge set upfront, then one PR is kicked off to start the chain
- Dependabot automatically rebases remaining PRs after each merge, minimizing manual intervention
- Added PR categorization (Safe/Needs review) and user confirmation for risky PRs
- Simplified safety criteria to leverage agent knowledge instead of hardcoded package lists

## Test plan

- [ ] Run `/merge-dependabot` skill when dependabot PRs are available
- [ ] Verify PRs are categorized correctly (Safe vs Needs review)
- [ ] Confirm auto-merge is set on all approved PRs before kicking off

🤖 Generated with [Claude Code](https://claude.com/claude-code)