### PR TITLE
Fix mobile location label appearing top-heavy in striped background

### DIFF
--- a/web/src/components/DashboardTabContent.tsx
+++ b/web/src/components/DashboardTabContent.tsx
@@ -47,7 +47,7 @@ export function DashboardTabContent({
         const firstIsPlaceholder = arranged.length > 0 && isPlaceholder(arranged[0]);
 
         const locationLabel = (
-          <h3 className="text-sm font-semibold font-display text-muted-foreground/80 uppercase tracking-wide px-1 md:px-0">
+          <h3 className="text-sm font-semibold font-display text-muted-foreground/80 uppercase tracking-wide px-1 md:px-0 translate-y-1.5 md:translate-y-0">
             {locationName}
           </h3>
         );


### PR DESCRIPTION
## Summary
- モバイル表示時の設置場所ラベルがシマシマ背景内で上寄りに見える問題を修正
- `translate-y-1.5` を使用してテキストを視覚的に6px下にシフト（レイアウトサイズに影響なし）
- タブレット以上では `translate-y-0` でリセット

## Test plan
- [x] lint, typecheck, test, build すべてパス
- [x] モバイル表示で設置場所ラベルがストライプ背景内で中央寄りに見えることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)