### PR TITLE
docs: update minimum Node.js version 20 to 22 in integration README

### DIFF
--- a/integration/README.md
+++ b/integration/README.md
@@ -39,7 +39,7 @@ integration/
 ### Prerequisites
 
 - Go 1.21 or later
-- Node.js 20 or later
+- Node.js 22 or later
 - npm
 
 ### Methods to Run Tests


### PR DESCRIPTION
## Summary
- Node.js 20 reached end-of-life
- Updates `integration/README.md` prerequisites to match the CI workflow (already on Node 22)

## Test plan
- `grep -n "Node.js 20" integration/README.md` returns no results

🤖 Generated with [Claude Code](https://claude.com/claude-code)