### PR TITLE
ci: parallelize web-ui checks and integration build steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,17 +136,25 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run linter
-        run: npm run lint
+      - name: Run lint, type check, and tests in parallel
+        run: |
+          set -euo pipefail
 
-      - name: Run type check
-        run: npm run typecheck
+          npm run lint &
+          lint_pid=$!
 
-      - name: Run tests
-        run: npm test
+          npm run typecheck &
+          typecheck_pid=$!
+
+          npm test -- --run &
+          test_pid=$!
+
+          wait $lint_pid
+          wait $typecheck_pid
+          wait $test_pid
 
       - name: Build application
-        run: npm run build
+        run: npm run build:vite
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
@@ -210,15 +218,22 @@ jobs:
           cache: "npm"
           cache-dependency-path: "./web/package-lock.json"
 
-      - name: Build Go server
-        run: go build -o echonet-list
-
-      - name: Build Web UI (for integration tests)
+      - name: Build Go server and Web UI in parallel
         run: |
-          cd web
-          npm ci
-          npm run build
-          cd ..
+          set -euo pipefail
+
+          go build -o echonet-list &
+          go_build_pid=$!
+
+          (
+            cd web
+            npm ci
+            npm run build:vite
+          ) &
+          web_build_pid=$!
+
+          wait $go_build_pid
+          wait $web_build_pid
 
           # Verify bundle exists
           if [ ! -d "web/bundle" ]; then


### PR DESCRIPTION
### Motivation
- Reduce CI wall-clock time by running independent web checks in parallel and overlapping Go and Web builds for integration tests.
- Avoid redundant TypeScript work during builds by using the Vite-specific build target `npm run build:vite` where appropriate.
- Improve failure visibility for backgrounded steps by enforcing stricter shell error handling.

### Description
- Update `.github/workflows/ci.yml` to run `npm run lint`, `npm run typecheck`, and `npm test -- --run` in the background inside the `web-ui` job and add `set -euo pipefail` to surface failures promptly.
- Change the `web-ui` build step to use `npm run build:vite` to avoid re-running TypeScript compilation already covered by the checks.
- Update the `integration` job to build the Go server (`go build -o echonet-list`) and the Web bundle (`cd web && npm ci && npm run build:vite`) in parallel, and preserve the existing `web/bundle` existence validation before running integration tests.

### Testing
- No automated tests were executed locally for this workflow-only change; the updated workflow will be validated by GitHub Actions on the next run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fd5aa99b48327b5d6da474513fa06)