### PR TITLE
CI: add concurrency, parallelize web UI checks, and adjust integration build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # Detect which files have changed to determine which tests to run
   changes:
@@ -136,17 +140,25 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run linter
-        run: npm run lint
+      - name: Run lint, type check, and tests in parallel
+        run: |
+          set -euo pipefail
 
-      - name: Run type check
-        run: npm run typecheck
+          npm run lint &
+          lint_pid=$!
 
-      - name: Run tests
-        run: npm test
+          npm run typecheck &
+          typecheck_pid=$!
+
+          npm test -- --run &
+          test_pid=$!
+
+          wait $lint_pid
+          wait $typecheck_pid
+          wait $test_pid
 
       - name: Build application
-        run: npm run build
+        run: npm run build:vite
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
@@ -177,13 +189,10 @@ jobs:
   integration:
     name: Integration Tests
     runs-on: ubuntu-latest
-    needs: [changes, go-server, web-ui, shell-scripts]
+    needs: [changes]
     # Run if any tests ran (server, web, or scripts)
     if: |
-      always() &&
-      (needs.changes.outputs.server == 'true' || needs.changes.outputs.web == 'true' || needs.changes.outputs.scripts == 'true') &&
-      !contains(needs.*.result, 'failure') &&
-      !contains(needs.*.result, 'cancelled')
+      needs.changes.outputs.server == 'true' || needs.changes.outputs.web == 'true' || needs.changes.outputs.scripts == 'true'
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -210,14 +219,13 @@ jobs:
           cache: "npm"
           cache-dependency-path: "./web/package-lock.json"
 
-      - name: Build Go server
-        run: go build -o echonet-list
-
       - name: Build Web UI (for integration tests)
         run: |
+          set -euo pipefail
+
           cd web
           npm ci
-          npm run build
+          npm run build:vite
           cd ..
 
           # Verify bundle exists


### PR DESCRIPTION
### Motivation

- Reduce CI queueing with a workflow-level `concurrency` group and cancel in-progress runs for the same ref.
- Speed up Web UI job by running lint, type-check, and tests in parallel and use the Vite build target.
- Simplify integration job dependencies and ensure the Web UI bundle is built and validated for integration tests.

### Description

- Added `concurrency` block to the workflow with `group: ci-${{ github.workflow }}-${{ github.ref }}` and `cancel-in-progress: true`.
- Changed the `web-ui` job to run lint, type checking, and tests in parallel using backgrounded commands and `wait`, replaced `npm run build` with `npm run build:vite`, and adjusted the test invocation to `npm test -- --run`.
- Simplified the `integration` job `needs` to only `changes` and removed cross-job result checks, removed the Go server build step, and updated the Web UI build to run `npm run build:vite` with `set -euo pipefail` and explicit verification that `web/bundle` exists before running `go test` with the `integration` tag.

### Testing

- No automated tests were executed as part of this PR; these changes are to the CI workflow and will take effect when the workflow runs on subsequent pushes or pull requests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fd5aa99b48327b5d6da474513fa06)