### PR TITLE
ci: include .nvmrc in setup-node cache-dependency-path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,9 @@ jobs:
         with:
           node-version-file: web/.nvmrc
           cache: "npm"
-          cache-dependency-path: "./web/package-lock.json"
+          cache-dependency-path: |
+            ./web/package-lock.json
+            ./web/.nvmrc
 
       - name: Install dependencies
         run: npm ci
@@ -219,7 +221,9 @@ jobs:
         with:
           node-version-file: web/.nvmrc
           cache: "npm"
-          cache-dependency-path: "./web/package-lock.json"
+          cache-dependency-path: |
+            ./web/package-lock.json
+            ./web/.nvmrc
 
       - name: Install web dependencies (for integration tests)
         run: |


### PR DESCRIPTION
## Summary

- `actions/setup-node` の組み込み npm cache key は `cache-dependency-path` のハッシュのみで構成され、`node-version-file` (`.nvmrc`) の中身は反映されない
- このため `.nvmrc` を更新して Node メジャーバージョンを上げても、`package-lock.json` が変わらない限り旧バージョン用にビルドされた native module を含む npm cache がヒットし続けるリスクがあった
- `web-ui` / `integration` ジョブの `cache-dependency-path` を複数行リストにし、`./web/package-lock.json` と `./web/.nvmrc` を併記することで、Node バージョン更新時に cache key が変わって確実に再構築されるようにする
- `npm-audit` ジョブは `cache:` 未指定（`npm audit --package-lock-only` で install しないため）なので変更不要
- paths-filter 側は既に `web/.nvmrc` が `web` フィルタに含まれているのでトリガ漏れは無し

参考: koizuka/drawing-practice#184 で同様の修正を実施済み。

## Test plan

- [x] `go fmt` / `go vet` / `go test ./...` / `go build` パス
- [x] `npm run lint` / `npm run typecheck` / `npm run test` / `npm run build` パス
- [ ] この PR の CI（`web-ui` / `integration`）が green になること
- [ ] 次回 `.nvmrc` 更新 PR の CI ログで、`Cache restored from key:` のキーが前回と異なり cache miss → 再 install 経路に入ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)